### PR TITLE
Revise submitter statistics permissions table

### DIFF
--- a/src/statistics/submitterStatistics.test.ts
+++ b/src/statistics/submitterStatistics.test.ts
@@ -1,0 +1,68 @@
+import type { ControlSubSettings } from "../settings.js";
+import { getSubmitterStatusCells, submitterNeedsGuidance } from "./submitterStatistics.js";
+
+const baseControlSubSettings: ControlSubSettings = {
+    evaluationDisabled: false,
+    reporterBlacklist: [],
+    trustedSubmitters: [],
+};
+
+test("existing trusted submitters show bold yes for bulk and trusted", () => {
+    const result = getSubmitterStatusCells(
+        { submitter: "TrustedUser", count: 500, ratio: 99 },
+        { ...baseControlSubSettings, trustedSubmitters: ["TrustedUser"] },
+        "bot-bouncer",
+    );
+
+    expect(result).toEqual(["**Yes**", "**Yes**", ""]);
+});
+
+test("existing bulk submitters show bold yes for bulk but are not recommended for trusted", () => {
+    const result = getSubmitterStatusCells(
+        { submitter: "BulkUser", count: 500, ratio: 99 },
+        { ...baseControlSubSettings, bulkSubmitters: ["BulkUser"] },
+        "bot-bouncer",
+    );
+
+    expect(result).toEqual(["**Yes**", "", ""]);
+});
+
+test("submitter status checks are case-insensitive", () => {
+    const result = getSubmitterStatusCells(
+        { submitter: "trusteduser", count: 500, ratio: 99 },
+        { ...baseControlSubSettings, trustedSubmitters: ["TrustedUser"] },
+        "bot-bouncer",
+    );
+
+    expect(result).toEqual(["**Yes**", "**Yes**", ""]);
+});
+
+test("users meeting recommendation criteria show recommended only when not already bulk or trusted", () => {
+    const result = getSubmitterStatusCells(
+        { submitter: "CandidateUser", count: 100, ratio: 90 },
+        baseControlSubSettings,
+        "bot-bouncer",
+    );
+
+    expect(result).toEqual(["Recommended", "Recommended", ""]);
+});
+
+
+
+test("trusted recommendation honors configured threshold and excluded users", () => {
+    const settings: ControlSubSettings = {
+        ...baseControlSubSettings,
+        trustedSubmitterAutoExcludedUsers: ["ExcludedUser"],
+        trustedSubmitterAutoThreshold: 95,
+    };
+
+    expect(getSubmitterStatusCells({ submitter: "HighButNotEnough", count: 100, ratio: 94 }, settings, "bot-bouncer")).toEqual(["Recommended", "", ""]);
+    expect(getSubmitterStatusCells({ submitter: "MeetsThreshold", count: 100, ratio: 95 }, settings, "bot-bouncer")).toEqual(["Recommended", "Recommended", ""]);
+    expect(getSubmitterStatusCells({ submitter: "ExcludedUser", count: 100, ratio: 100 }, settings, "bot-bouncer")).toEqual(["Recommended", "", ""]);
+});
+
+test("guidance flags require both reversal rate and estimated reversal workload", () => {
+    expect(submitterNeedsGuidance({ submitter: "LowVolume", count: 10, ratio: 0 })).toBe(false);
+    expect(submitterNeedsGuidance({ submitter: "HighReversalRate", count: 100, ratio: 80 })).toBe(true);
+    expect(submitterNeedsGuidance({ submitter: "HighEstimatedReversals", count: 1_000, ratio: 95 })).toBe(true);
+});

--- a/src/statistics/submitterStatistics.ts
+++ b/src/statistics/submitterStatistics.ts
@@ -5,15 +5,76 @@ import { subMonths } from "date-fns";
 import json2md from "json2md";
 import { ZMember } from "@devvit/protos";
 import { getControlSubSettings } from "../settings.js";
+import type { ControlSubSettings } from "../settings.js";
 import { StatsUserEntry } from "../scheduler/sixHourlyJobs.js";
 
-interface SubmitterStatistic {
+export interface SubmitterStatistic {
     submitter: string;
     count: number;
     ratio: number;
 }
 
 const SUBMITTER_SUCCESS_RATE_KEY = "SubmitterSuccessRate";
+const DEFAULT_THRESHOLD_FOR_SUBMITTER_CALCULATION = 10;
+const BULK_RECOMMENDATION_MINIMUM_COUNT = 25;
+const BULK_RECOMMENDATION_MINIMUM_RATIO = 85;
+const TRUSTED_RECOMMENDATION_MINIMUM_COUNT = 100;
+const TRUSTED_RECOMMENDATION_MINIMUM_RATIO = 90;
+
+type SubmitterStatusCell = "**Yes**" | "Recommended" | "";
+
+function usernameIsInList (username: string, list: string[] | undefined): boolean {
+    return list?.some(item => item.toLowerCase() === username.toLowerCase()) ?? false;
+}
+
+export function submitterMeetsBulkRecommendationCriteria (item: SubmitterStatistic): boolean {
+    return item.count >= BULK_RECOMMENDATION_MINIMUM_COUNT && item.ratio >= BULK_RECOMMENDATION_MINIMUM_RATIO;
+}
+
+export function submitterMeetsTrustedRecommendationCriteria (item: SubmitterStatistic, minimumRatio = TRUSTED_RECOMMENDATION_MINIMUM_RATIO): boolean {
+    return item.count >= TRUSTED_RECOMMENDATION_MINIMUM_COUNT && item.ratio >= minimumRatio;
+}
+
+export function submitterNeedsGuidance (item: SubmitterStatistic): boolean {
+    const reversalRate = 100 - item.ratio;
+    const estimatedReversals = item.count * reversalRate / 100;
+
+    return (estimatedReversals >= 20 && reversalRate >= 20) || (estimatedReversals >= 50 && reversalRate >= 5);
+}
+
+function submitterHasTrustedStatus (submitter: string, controlSubSettings: ControlSubSettings, appSlug: string): boolean {
+    return usernameIsInList(submitter, controlSubSettings.trustedSubmitters) || submitter.toLowerCase().startsWith(appSlug.toLowerCase());
+}
+
+function submitterHasBulkStatus (submitter: string, controlSubSettings: ControlSubSettings, appSlug: string): boolean {
+    return usernameIsInList(submitter, controlSubSettings.bulkSubmitters) || submitterHasTrustedStatus(submitter, controlSubSettings, appSlug);
+}
+
+export function getSubmitterStatusCells (item: SubmitterStatistic, controlSubSettings: ControlSubSettings, appSlug: string): [SubmitterStatusCell, SubmitterStatusCell, SubmitterStatusCell] {
+    const isTrustedSubmitter = submitterHasTrustedStatus(item.submitter, controlSubSettings, appSlug);
+    const isBulkSubmitter = submitterHasBulkStatus(item.submitter, controlSubSettings, appSlug);
+    const isExistingSubmitter = isBulkSubmitter || isTrustedSubmitter;
+    const isTrustedRecommendationExcluded = usernameIsInList(item.submitter, controlSubSettings.trustedSubmitterAutoExcludedUsers);
+    const trustedRecommendationMinimumRatio = Math.max(controlSubSettings.trustedSubmitterAutoThreshold ?? TRUSTED_RECOMMENDATION_MINIMUM_RATIO, TRUSTED_RECOMMENDATION_MINIMUM_RATIO);
+
+    let bulkCell: SubmitterStatusCell = "";
+    if (isBulkSubmitter) {
+        bulkCell = "**Yes**";
+    } else if (submitterMeetsBulkRecommendationCriteria(item)) {
+        bulkCell = "Recommended";
+    }
+
+    let trustedCell: SubmitterStatusCell = "";
+    if (isTrustedSubmitter) {
+        trustedCell = "**Yes**";
+    } else if (!isExistingSubmitter && !isTrustedRecommendationExcluded && submitterMeetsTrustedRecommendationCriteria(item, trustedRecommendationMinimumRatio)) {
+        trustedCell = "Recommended";
+    }
+
+    const needsGuidanceCell = submitterNeedsGuidance(item) ? "**Yes**" : "";
+
+    return [bulkCell, trustedCell, needsGuidanceCell];
+}
 
 export async function updateSubmitterStatistics (allStatuses: StatsUserEntry[], context: JobContext) {
     const organicStatuses: Record<string, number> = {};
@@ -39,6 +100,7 @@ export async function updateSubmitterStatistics (allStatuses: StatsUserEntry[], 
     const submitterStatistics: SubmitterStatistic[] = [];
     const successRatesToStore: ZMember[] = [];
     const controlSubSettings = await getControlSubSettings(context);
+    const thresholdForSubmitterCalculation = controlSubSettings.thresholdForSubmitterCalculation ?? DEFAULT_THRESHOLD_FOR_SUBMITTER_CALCULATION;
 
     for (const user of distinctUsers) {
         const organicCount = organicStatuses[user] ?? 0;
@@ -47,7 +109,7 @@ export async function updateSubmitterStatistics (allStatuses: StatsUserEntry[], 
         const ratio = Math.round(100 * bannedCount / totalCount);
         submitterStatistics.push({ submitter: user, count: totalCount, ratio });
 
-        if (organicCount + bannedCount >= (controlSubSettings.thresholdForSubmitterCalculation ?? 10)) {
+        if (organicCount + bannedCount >= thresholdForSubmitterCalculation) {
             successRatesToStore.push({ member: user, score: ratio });
         }
     }
@@ -57,16 +119,16 @@ export async function updateSubmitterStatistics (allStatuses: StatsUserEntry[], 
     wikiContent.push({ p: "This lists all users who have submitted an account for review within the last month." });
 
     const tableRows = submitterStatistics
-        .filter(item => item.count >= (controlSubSettings.thresholdForSubmitterCalculation ?? 10))
+        .filter(item => item.count >= thresholdForSubmitterCalculation)
         .sort((a, b) => b.count - a.count)
         .map(item => [
             item.submitter,
             item.count.toLocaleString(),
             `${item.ratio}%`,
-            controlSubSettings.trustedSubmitters.includes(item.submitter) || item.submitter.startsWith(context.appSlug) ? "Yes" : "",
+            ...getSubmitterStatusCells(item, controlSubSettings, context.appSlug),
         ]);
 
-    wikiContent.push({ table: { headers: ["Submitter", "Total Accounts", "Ratio", "Trusted"], rows: tableRows } });
+    wikiContent.push({ table: { headers: ["Submitter", "Total Accounts", "Ratio", "Bulk", "Trusted", "Needs Guidance"], rows: tableRows } });
     wikiContent.push({ p: "This page updates once a day at midnight UTC, and may update more frequently." });
 
     const subredditName = context.subredditName ?? await context.reddit.getCurrentSubredditName();


### PR DESCRIPTION
Closes #440

Updates submitter statistics to distinguish existing bulk/trusted permissions, recommended permission changes, and submitters needing guidance.