### PR TITLE
Run content evaluation on edited posts and comments

### DIFF
--- a/devvit.json
+++ b/devvit.json
@@ -9,6 +9,7 @@
             "onPostCreate",
             "onCommentCreate",
             "onCommentUpdate",
+            "onPostUpdate",
             "onPostFlairUpdate",
             "onPostDelete",
             "onPostSubmit",

--- a/src/dataStore.ts.bak-circular-import
+++ b/src/dataStore.ts.bak-circular-import
@@ -1,0 +1,421 @@
+import { TriggerContext, CreateModNoteOptions, UserSocialLink, TxClientLike, RedisClient } from "@devvit/public-api";
+import _ from "lodash";
+import { setCleanupForSubmittersAndMods, setCleanupForUser } from "./cleanup.js";
+import { CONTROL_SUBREDDIT } from "./constants.js";
+import { addDays, addHours, addMinutes, subDays, subHours } from "date-fns";
+import pluralize from "pluralize";
+import { getControlSubSettings } from "./settings.js";
+import { isCommentId, isLinkId } from "@devvit/public-api/types/tid.js";
+import { deleteAccountInitialEvaluationResults } from "./handleControlSubAccountEvaluation.js";
+import json2md from "json2md";
+import { getUsernameFromUrl, sendMessageToWebhook } from "./utility.js";
+import { getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
+import { storeClassificationEvent } from "./statistics/classificationStatistics.js";
+import { USER_DEFINED_HANDLES_POSTS } from "./statistics/definedHandlesStatistics.js";
+import { ZMember } from "@devvit/protos";
+import { getUserSocialLinks, hGetAllChunked } from "devvit-helpers";
+import { removeUserFromReversalsQueue } from "./modmail/evaluatorReversals.js";
+
+const TEMP_DECLINE_STORE = "TempDeclineStore";
+const RECENT_CHANGES_STORE = "RecentChangesStore";
+
+export const BIO_TEXT_STORE = "BioTextStore";
+export const DISPLAY_NAME_STORE = "DisplayNameStore";
+export const SOCIAL_LINKS_STORE = "SocialLinksStore";
+
+export const AGGREGATE_STORE = "AggregateStore";
+
+export enum UserStatus {
+    Pending = "pending",
+    Banned = "banned",
+    Service = "service",
+    Organic = "organic",
+    Purged = "purged",
+    Retired = "retired",
+    Inactive = "inactive",
+}
+
+export enum UserFlag {
+    HackedAndRecovered = "recovered",
+    Scammed = "scammed",
+    Locked = "locked",
+    FutureNSFW = "futurensfw",
+}
+
+const eligibleFlagsForStatus: Record<UserFlag, UserStatus[]> = {
+    [UserFlag.HackedAndRecovered]: [UserStatus.Pending, UserStatus.Organic],
+    [UserFlag.Scammed]: [UserStatus.Pending, UserStatus.Organic],
+    [UserFlag.Locked]: [UserStatus.Banned],
+    [UserFlag.FutureNSFW]: [UserStatus.Organic],
+};
+
+export interface UserDetails {
+    trackingPostId: string;
+    userStatus: UserStatus;
+    lastStatus?: UserStatus;
+    lastUpdate: number;
+    submitter?: string;
+    operator?: string;
+    reportedAt?: number;
+    /**
+     * @deprecated This was only used for wiki functionality, which has been removed.
+     */
+    mostRecentActivity?: number;
+    flags?: UserFlag[];
+}
+
+export const ALL_POTENTIAL_USER_PREFIXES = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".split("");
+
+function getStoreKey (username: string): string {
+    if (username.length === 0) {
+        throw new Error("Empty username provided to getStoreKey");
+    }
+    return `UserStore~${username[0]}`;
+}
+
+interface DataStoreExtractFilter {
+    since?: Date;
+    lastUpdateSince?: Date;
+    statuses?: UserStatus[];
+    omitFlags?: UserFlag[];
+    submitter?: string[];
+    usernameRegex?: RegExp;
+}
+
+export async function getDataStoreFiltered (prefix: string, context: TriggerContext, filter?: DataStoreExtractFilter): Promise<Record<string, UserDetails>> {
+    const data = await hGetAllChunked(context.redis.global as RedisClient, getStoreKey(prefix), 10000);
+    if (!filter) {
+        return _.fromPairs(Object.entries(data).map(([key, value]) => [key, JSON.parse(value) as UserDetails]));
+    }
+
+    const sinceTime = filter.since ? filter.since.getTime() : undefined;
+    const lastUpdateSinceTime = filter.lastUpdateSince ? filter.lastUpdateSince.getTime() : undefined;
+    const omitFlags = filter.omitFlags ?? [];
+
+    const filteredData: Record<string, UserDetails> = {};
+
+    Object.entries(data).forEach(([username, value]) => {
+        const details = JSON.parse(value) as UserDetails;
+        if (sinceTime && details.reportedAt && details.reportedAt < sinceTime) {
+            return;
+        }
+
+        if (lastUpdateSinceTime && details.lastUpdate < lastUpdateSinceTime) {
+            return;
+        }
+
+        if (filter.statuses && !filter.statuses.includes(details.userStatus)) {
+            return;
+        }
+
+        if (omitFlags.length > 0 && details.flags?.some(flag => omitFlags.includes(flag))) {
+            return;
+        }
+
+        if (filter.submitter && !filter.submitter.includes(details.submitter ?? "")) {
+            return;
+        }
+
+        if (filter.usernameRegex && !filter.usernameRegex.test(username)) {
+            return;
+        }
+
+        filteredData[username] = details;
+    });
+
+    return filteredData;
+}
+
+export async function getFullDataStore (context: TriggerContext, filter?: DataStoreExtractFilter): Promise<Record<string, UserDetails>> {
+    const dataArray = await Promise.all(ALL_POTENTIAL_USER_PREFIXES.map(prefix => getDataStoreFiltered(prefix, context, filter)));
+    const data = Object.assign({}, ...dataArray) as Record<string, UserDetails>;
+
+    return { ...data };
+}
+
+export async function getAllKnownUsers (context: TriggerContext): Promise<string[]> {
+    const users = await Promise.all(ALL_POTENTIAL_USER_PREFIXES.map(prefix => context.redis.global.hKeys(getStoreKey(prefix))));
+
+    return _.uniq([...users.flat()]);
+}
+
+export async function getUserStatus (username: string, context: TriggerContext) {
+    const value = await context.redis.global.hGet(getStoreKey(username), username);
+    if (value) {
+        return JSON.parse(value) as UserDetails;
+    }
+}
+
+async function addModNote (options: CreateModNoteOptions, context: TriggerContext) {
+    try {
+        await context.reddit.addModNote(options);
+    } catch {
+        console.warn(`Failed to add mod note for ${options.user}, likely deleted account.`);
+    }
+}
+
+export async function writeUserStatus (username: string, details: UserDetails, context: TriggerContext) {
+    try {
+        await context.redis.global.hSet(getStoreKey(username), { [username]: JSON.stringify(details) });
+    } catch (error) {
+        console.error(`Failed to write user status of ${details.userStatus} for ${username}:`, error);
+        throw new Error(`Failed to write user status for ${username}`);
+    }
+}
+
+function usernamesMatch (username1: string | undefined, username2: string | undefined): boolean {
+    if (!username1 || !username2) {
+        return false;
+    }
+
+    return username1.toLowerCase() === username2.toLowerCase();
+}
+
+export function shouldStoreClassificationEvent (currentStatus: UserDetails | undefined, details: UserDetails, appSlug: string | undefined): boolean {
+    if (currentStatus?.userStatus !== UserStatus.Pending || details.userStatus === UserStatus.Pending || !details.operator) {
+        return false;
+    }
+
+    if (usernamesMatch(details.operator, appSlug)) {
+        return false;
+    }
+
+    if (usernamesMatch(details.operator, currentStatus.submitter) || usernamesMatch(details.operator, details.submitter)) {
+        return false;
+    }
+
+    return true;
+}
+
+export async function setUserStatus (username: string, details: UserDetails, context: TriggerContext) {
+    if (context.subredditName === CONTROL_SUBREDDIT && !isLinkId(details.trackingPostId) && !isCommentId(details.trackingPostId)) {
+        throw new Error(`Tracking post ID is missing or invalid for ${username}: ${details.trackingPostId}!`);
+    }
+
+    const currentStatus = await getUserStatus(username, context);
+
+    const statusesForLastStatusCopy = [
+        UserStatus.Banned,
+        UserStatus.Service,
+        UserStatus.Organic,
+    ];
+
+    if (currentStatus?.userStatus && statusesForLastStatusCopy.includes(currentStatus.userStatus)) {
+        details.lastStatus = currentStatus.userStatus;
+    }
+
+    // Set the reported at date from the original date, or current date/time if not set.
+    details.reportedAt ??= currentStatus?.reportedAt ?? new Date().getTime();
+
+    if (details.flags && details.flags.length > 0) {
+        details.flags = details.flags.filter(flag => eligibleFlagsForStatus[flag].includes(details.userStatus));
+        if (details.flags.length === 0) {
+            console.log("User flags cleared due to new status.");
+            delete details.flags;
+        }
+    }
+
+    await writeUserStatus(username, details, context);
+
+    if (context.subredditName === CONTROL_SUBREDDIT) {
+        let overrideDate: Date | undefined;
+        if (details.userStatus === UserStatus.Pending && !currentStatus) {
+            overrideDate = addMinutes(new Date(), 2);
+        } else if (details.userStatus === UserStatus.Pending || details.userStatus === UserStatus.Purged || details.userStatus === UserStatus.Retired) {
+            overrideDate = addHours(new Date(), 1);
+        } else if (details.flags?.includes(UserFlag.FutureNSFW)) {
+            overrideDate = addDays(new Date(), 7);
+        } else if (details.userStatus === UserStatus.Inactive) {
+            overrideDate = addDays(new Date(), 7);
+        }
+
+        await setCleanupForUser(username, context.redis, overrideDate);
+
+        const submittersAndMods = _.uniq(_.compact([details.submitter, details.operator]));
+        await setCleanupForSubmittersAndMods(submittersAndMods, context);
+
+        if (details.userStatus !== currentStatus?.userStatus) {
+            await updateAggregate(details.userStatus, 1, context.redis);
+            if (currentStatus) {
+                await updateAggregate(currentStatus.userStatus, -1, context.redis);
+            }
+        }
+    }
+
+    if (context.subredditName === CONTROL_SUBREDDIT && currentStatus?.userStatus !== details.userStatus && details.userStatus !== UserStatus.Pending) {
+        await addModNote({
+            subreddit: context.subredditName,
+            user: username,
+            note: `Status changed to ${details.userStatus} by ${details.operator}.`,
+        }, context);
+    }
+
+    const classificationOperator = details.operator;
+    if (classificationOperator && shouldStoreClassificationEvent(currentStatus, details, context.appSlug)) {
+        await storeClassificationEvent(classificationOperator, context);
+    }
+
+    if (details.userStatus !== UserStatus.Pending && details.userStatus !== UserStatus.Purged && details.userStatus !== UserStatus.Retired) {
+        await context.redis.global.zAdd(RECENT_CHANGES_STORE, { member: username, score: new Date().getTime() });
+    }
+
+    if (details.userStatus === UserStatus.Banned) {
+        await removeUserFromReversalsQueue(username, context);
+    }
+}
+
+export async function removeStaleRecentChangesEntries (context: TriggerContext) {
+    const removedEntries = await context.redis.global.zRemRangeByScore(RECENT_CHANGES_STORE, 0, subDays(new Date(), 7).getTime());
+    console.log(`Data Store: Cleaned up ${removedEntries} entries from the recent changes store.`);
+}
+
+export async function deleteUserStatus (username: string, context: TriggerContext) {
+    if (context.subredditName !== CONTROL_SUBREDDIT) {
+        throw new Error("deleteUserStatus can only be called from the control subreddit.");
+    }
+
+    await context.redis.global.hDel(getStoreKey(username), [username]);
+    await context.redis.global.zRem(RECENT_CHANGES_STORE, [username]);
+
+    await deleteAccountInitialEvaluationResults(username, context);
+    await context.redis.hDel(BIO_TEXT_STORE, [username]);
+    await context.redis.hDel(DISPLAY_NAME_STORE, [username]);
+    await context.redis.hDel(SOCIAL_LINKS_STORE, [username]);
+    await context.redis.hDel(USER_DEFINED_HANDLES_POSTS, [username]);
+
+    await context.redis.global.zRem(TEMP_DECLINE_STORE, [username]);
+}
+
+export async function getUsernameFromPostId (postId: string, context: TriggerContext): Promise<string | undefined> {
+    const post = await context.reddit.getPostById(postId);
+    return getUsernameFromUrl(post.url);
+}
+
+export async function updateAggregate (type: UserStatus, incrBy: number, redis: TxClientLike | RedisClient) {
+    await redis.zIncrBy(AGGREGATE_STORE, type, incrBy);
+}
+
+export async function removeRecordOfSubmitterOrMod (username: string, context: TriggerContext) {
+    console.log(`Cleanup: Removing records of ${username} as submitter or operator`);
+    const data = await getFullDataStore(context, {
+        submitter: [username],
+    });
+
+    const entries = Object.entries(data).map(([key, value]) => ({ username: key, details: value }));
+
+    let entriesUpdated = 0;
+    for (const entry of entries.filter(item => item.details.operator === username || item.details.submitter === username)) {
+        const updatedDetails = { ...entry.details };
+        if (updatedDetails.operator === username) {
+            delete updatedDetails.operator;
+        }
+        if (updatedDetails.submitter === username) {
+            delete updatedDetails.submitter;
+        }
+
+        await writeUserStatus(entry.username, updatedDetails, context);
+        entriesUpdated++;
+    }
+
+    console.log(`Cleanup: Removed ${entriesUpdated} ${pluralize("record", entriesUpdated)} of ${username} as submitter or operator`);
+}
+
+export async function storeInitialAccountProperties (username: string, context: TriggerContext) {
+    const userExtended = await getUserExtended(username, context);
+
+    if (!userExtended) {
+        return;
+    }
+
+    const promises: Promise<number>[] = [];
+    if (userExtended.userDescription) {
+        promises.push(context.redis.hSet(BIO_TEXT_STORE, { [username]: userExtended.userDescription }));
+        console.log(`Data Store: Stored bio for ${username}`);
+    }
+
+    if (userExtended.displayName && userExtended.displayName !== username && userExtended.displayName !== `u_${username}`) {
+        promises.push(context.redis.hSet(DISPLAY_NAME_STORE, { [username]: userExtended.displayName }));
+        console.log(`Data Store: Stored display name for ${username}`);
+    }
+
+    const socialLinks = await getUserSocialLinks(username, context.metadata);
+    if (socialLinks.length > 0) {
+        promises.push(context.redis.hSet(SOCIAL_LINKS_STORE, { [username]: JSON.stringify(socialLinks) }));
+        console.log(`Data Store: Stored social links for ${username}`);
+    }
+
+    await Promise.all(promises);
+}
+
+export async function getInitialAccountProperties (username: string, context: TriggerContext) {
+    const [bioText, displayName, socialLinks] = await Promise.all([
+        context.redis.hGet(BIO_TEXT_STORE, username),
+        context.redis.hGet(DISPLAY_NAME_STORE, username),
+        context.redis.hGet(SOCIAL_LINKS_STORE, username),
+    ]);
+
+    return {
+        bioText,
+        displayName,
+        socialLinks: socialLinks ? JSON.parse(socialLinks) as UserSocialLink[] : [],
+    };
+}
+
+export async function addUserToTempDeclineStore (username: string, context: TriggerContext) {
+    await context.redis.global.zAdd(TEMP_DECLINE_STORE, { member: username, score: new Date().getTime() });
+    await context.redis.global.zAdd(RECENT_CHANGES_STORE, { member: username, score: new Date().getTime() });
+
+    // Remove stale entries.
+    await context.redis.global.zRemRangeByScore(TEMP_DECLINE_STORE, 0, subHours(new Date(), 1).getTime());
+}
+
+export async function isUserInTempDeclineStore (username: string, context: TriggerContext): Promise<boolean> {
+    return await context.redis.global.zScore(TEMP_DECLINE_STORE, username).then(exists => exists !== undefined);
+}
+
+export async function getRecentlyChangedUsers (since: Date, now: Date, context: TriggerContext): Promise<ZMember[]> {
+    return await context.redis.global.zRange(RECENT_CHANGES_STORE, since.getTime(), now.getTime(), { by: "score" });
+}
+
+export async function checkDataStoreIntegrity (context: TriggerContext) {
+    const misplacedEntries: { username: string; actualPrefix: string; inCorrectStore: boolean }[] = [];
+
+    for (const prefix of ALL_POTENTIAL_USER_PREFIXES) {
+        const storeKey = getStoreKey(prefix);
+        const keys = await context.redis.global.hKeys(storeKey);
+
+        for (const key of keys.filter(key => !key.startsWith(prefix))) {
+            const entryFromCorrectStore = await context.redis.global.hGet(getStoreKey(key[0]), key);
+            misplacedEntries.push({ username: key, actualPrefix: key[0], inCorrectStore: !!entryFromCorrectStore });
+        }
+    }
+
+    if (misplacedEntries.length === 0) {
+        return;
+    }
+
+    console.warn("Data Store: Found misplaced entries:", JSON.stringify(misplacedEntries, null, 2));
+
+    const controlSubSettings = await getControlSubSettings(context);
+    const webhook = controlSubSettings.monitoringWebhook;
+    if (!webhook) {
+        console.warn("Data Store: No monitoring webhook configured, cannot send alert.");
+        return;
+    }
+
+    const message: json2md.DataObject[] = [
+        { p: `Found ${misplacedEntries.length} misplaced ${pluralize("entry", misplacedEntries.length)} in the data store.` },
+        {
+            table: {
+                headers: ["Username", "Actual Prefix", "In Correct Store"],
+                rows: misplacedEntries.map(entry => [
+                    entry.username,
+                    entry.actualPrefix,
+                    entry.inCorrectStore ? "Yes" : "No",
+                ]),
+            },
+        },
+    ];
+
+    await sendMessageToWebhook(webhook, json2md(message));
+}

--- a/src/handleClientPostOrComment.ts
+++ b/src/handleClientPostOrComment.ts
@@ -1,5 +1,5 @@
 import { Post, Comment, TriggerContext, SettingsValues, JSONValue, UserSocialLink } from "@devvit/public-api";
-import { CommentCreate, CommentUpdate, PostCreate } from "@devvit/protos";
+import { CommentCreate, CommentUpdate, PostCreate, PostUpdate } from "@devvit/protos";
 import { addDays, addSeconds, formatDate, subMinutes } from "date-fns";
 import { getUserStatus, UserDetails, UserStatus } from "./dataStore.js";
 import { addUserToModqueueRemovalStore, isUserWhitelisted, recordBan, recordUserContentCreation } from "./handleClientSubredditClassificationChanges.js";
@@ -12,6 +12,41 @@ import { getEvaluatorVariables } from "./userEvaluation/evaluatorVariables.js";
 import { recordBanForSummary } from "./modmail/actionSummary.js";
 import { expireKeyAt, isBanned, isContributor } from "devvit-helpers";
 import { filterContent, getPostOrCommentById, getTrueUsername, getUserExtended, hasTriggerBeenHandled } from "@fsvreddit/fsv-devvit-helpers";
+
+interface EditedContentPreEvaluator {
+    preEvaluatePost: (post: Post) => boolean | Promise<boolean>;
+    preEvaluateComment: (event: CommentCreate | CommentUpdate) => boolean | Promise<boolean>;
+    preEvaluatePostEdit?: (post: Post) => boolean | Promise<boolean>;
+    preEvaluateCommentEdit?: (event: CommentUpdate) => boolean | Promise<boolean>;
+}
+
+interface PotentialBotCheckOptions {
+    contentEdited?: boolean;
+}
+
+async function preEvaluateEditedPost (evaluator: EditedContentPreEvaluator, post: Post): Promise<boolean> {
+    if (await Promise.resolve(evaluator.preEvaluatePost(post))) {
+        return true;
+    }
+
+    if (typeof evaluator.preEvaluatePostEdit === "function") {
+        return await Promise.resolve(evaluator.preEvaluatePostEdit(post));
+    }
+
+    return false;
+}
+
+async function preEvaluateEditedComment (evaluator: EditedContentPreEvaluator, event: CommentUpdate): Promise<boolean> {
+    if (await Promise.resolve(evaluator.preEvaluateComment(event))) {
+        return true;
+    }
+
+    if (typeof evaluator.preEvaluateCommentEdit === "function") {
+        return await Promise.resolve(evaluator.preEvaluateCommentEdit(event));
+    }
+
+    return false;
+}
 
 export async function handleClientPostCreate (event: PostCreate, context: TriggerContext) {
     if (context.subredditName === CONTROL_SUBREDDIT) {
@@ -59,6 +94,71 @@ export async function handleClientPostCreate (event: PostCreate, context: Trigge
         const settings = await context.settings.getAll();
         await checkAndReportPotentialBot(username, post, settings, variables, context);
     }
+}
+
+export async function handleClientPostUpdate (event: PostUpdate, context: TriggerContext) {
+    if (context.subredditName === CONTROL_SUBREDDIT) {
+        return;
+    }
+
+    if (!event.post?.id) {
+        console.error("Content Edit: PostUpdate event missing post information", JSON.stringify(event));
+        return;
+    }
+
+    if (await hasTriggerBeenHandled(context.redis, `PostUpdate:${event.post.id}`, { expiration: addSeconds(new Date(), 10) })) {
+        return;
+    }
+
+    const post = await context.reddit.getPostById(event.post.id);
+    const username = event.author?.name
+        ? await getTrueUsername(context.reddit, event.author.name, event.post.id)
+        : post.authorName;
+
+    console.log(`Content Edit: PostUpdate ${event.post.id} by ${username}`);
+
+    if (username === "AutoModerator" || username === `${context.subredditName}-ModTeam` || username === "[deleted]") {
+        return;
+    }
+
+    const currentStatus = await getUserStatus(username, context);
+    if (currentStatus) {
+        return;
+    }
+
+    const variables = await getEvaluatorVariables(context);
+
+    let possibleBot = false;
+    for (const Evaluator of ALL_RELEVANT_EVALUTORS) {
+        const evaluator = new Evaluator(context, [], undefined, variables);
+        if (evaluator.evaluatorDisabled()) {
+            continue;
+        }
+
+        if (await preEvaluateEditedPost(evaluator as EditedContentPreEvaluator, post)) {
+            possibleBot = true;
+            break;
+        }
+    }
+
+    if (!possibleBot) {
+        return;
+    }
+
+    const redisKey = `lastBotCheckForUser:${username}`;
+    const recentlyChecked = await context.redis.get(redisKey);
+    if (recentlyChecked) {
+        // Allow some rechecks within 15 minutes, to find rapid fire bots.
+        const lastCheck = new Date(parseInt(recentlyChecked));
+        if (lastCheck < subMinutes(new Date(), 15)) {
+            return;
+        }
+    }
+
+    const settings = await context.settings.getAll();
+    await checkAndReportPotentialBot(username, post, settings, variables, context, { contentEdited: true });
+
+    await context.redis.set(redisKey, new Date().getTime().toString(), { expiration: addDays(new Date(), 2) });
 }
 
 /**
@@ -177,7 +277,7 @@ export async function handleClientCommentUpdate (event: CommentUpdate, context: 
             continue;
         }
 
-        if (evaluator.preEvaluateCommentEdit(fixedEvent)) {
+        if (await preEvaluateEditedComment(evaluator as EditedContentPreEvaluator, fixedEvent)) {
             possibleBot = true;
             break;
         }
@@ -198,7 +298,7 @@ export async function handleClientCommentUpdate (event: CommentUpdate, context: 
     }
 
     const settings = await context.settings.getAll();
-    await checkAndReportPotentialBot(fixedEvent.author.name, fixedEvent, settings, variables, context);
+    await checkAndReportPotentialBot(fixedEvent.author.name, fixedEvent, settings, variables, context, { contentEdited: true });
 
     await context.redis.set(redisKey, new Date().getTime().toString(), { expiration: addDays(new Date(), 2) });
 }
@@ -309,7 +409,7 @@ async function handleContentCreation (username: string, currentStatus: UserDetai
     await Promise.allSettled(promises);
 }
 
-async function checkAndReportPotentialBot (username: string, target: Post | CommentCreate, settings: SettingsValues, variables: Record<string, JSONValue>, context: TriggerContext) {
+async function checkAndReportPotentialBot (username: string, target: Post | CommentCreate | CommentUpdate, settings: SettingsValues, variables: Record<string, JSONValue>, context: TriggerContext, options: PotentialBotCheckOptions = {}) {
     const user = await getUserExtended(username, context);
     if (!user) {
         return;
@@ -334,11 +434,17 @@ async function checkAndReportPotentialBot (username: string, target: Post | Comm
         }
 
         if (target instanceof Post) {
-            if (!evaluator.preEvaluatePost(target)) {
+            const shouldEvaluatePost = options.contentEdited
+                ? await preEvaluateEditedPost(evaluator as EditedContentPreEvaluator, target)
+                : await Promise.resolve(evaluator.preEvaluatePost(target));
+            if (!shouldEvaluatePost) {
                 continue;
             }
         } else {
-            if (!await Promise.resolve(evaluator.preEvaluateComment(target))) {
+            const shouldEvaluateComment = options.contentEdited
+                ? await preEvaluateEditedComment(evaluator as EditedContentPreEvaluator, target as CommentUpdate)
+                : await Promise.resolve(evaluator.preEvaluateComment(target as CommentCreate));
+            if (!shouldEvaluateComment) {
                 continue;
             }
         }

--- a/src/handleReportUser.ts.bak-conflict
+++ b/src/handleReportUser.ts.bak-conflict
@@ -1,0 +1,302 @@
+import { Context, MenuItemOnPressEvent, JSONObject, FormOnSubmitEvent, FormFunction, TriggerContext } from "@devvit/public-api";
+import { CONTROL_SUBREDDIT } from "./constants.js";
+import { formatTimeSince, getUserOrUndefined, isBannedWithCache, isModeratorWithCache } from "./utility.js";
+import { getUserStatus, UserStatus } from "./dataStore.js";
+import { addExternalSubmissionFromClientSub } from "./externalSubmissions.js";
+import { queryForm, reportForm } from "./main.js";
+import { addDays, addMinutes, subMonths } from "date-fns";
+import { getControlSubSettings } from "./settings.js";
+import { handleControlSubReportUser } from "./handleControlSubMenu.js";
+import { recordReportForSummary } from "./modmail/actionSummary.js";
+import { canUserReceiveFeedback } from "./submissionFeedback.js";
+import { isLinkId } from "@devvit/public-api/types/tid.js";
+import { addClassificationQueryToQueue } from "./modmail/classificationQuery.js";
+import { getPostOrCommentById } from "@fsvreddit/fsv-devvit-helpers";
+import { getRecentConfigRevisionUserHit } from "./configRevisionReceipts.js";
+
+enum ReportFormField {
+    ReportContext = "reportContext",
+    PublicContext = "publicContext",
+    SendFeedback = "sendFeedback",
+}
+
+export const reportFormDefinition: FormFunction = data => ({
+    title: `Report u/${data.username} to Bot Bouncer`,
+    description: `Thank you for reporting this user. Our team will review the account manually and take appropriate action.${data.configRevisionNotice ? `\n\n${data.configRevisionNotice as string}` : ""}`,
+    fields: [
+        {
+            type: "paragraph",
+            label: "Optional. Please provide more information that might help us understand why this is a bot",
+            helpText: "This is in case it is not obvious that this is a bot",
+            lineHeight: 4,
+            name: ReportFormField.ReportContext,
+        },
+        {
+            type: "boolean",
+            label: "Show the above text publicly on the post on r/BotBouncer",
+            helpText: "Your username will be kept private",
+            defaultValue: true,
+            name: ReportFormField.PublicContext,
+        },
+        {
+            type: "boolean",
+            label: "Receive a notification when this account is classified",
+            helpText: data.feedbackHelpText as string,
+            disabled: data.feedbackDisabled as boolean,
+            defaultValue: data.userFeedbackPreference as boolean | undefined ?? false,
+            name: ReportFormField.SendFeedback,
+        },
+    ],
+});
+
+function getAlreadyReportedKey (username: string): string {
+    return `userAlreadyReported:${username}`;
+}
+
+async function getAlreadyReported (username: string, context: TriggerContext): Promise<boolean> {
+    if (await context.redis.exists(getAlreadyReportedKey(username))) {
+        return true;
+    }
+    return false;
+}
+
+async function setAlreadyReported (username: string, context: TriggerContext) {
+    await context.redis.set(getAlreadyReportedKey(username), "", { expiration: addMinutes(new Date(), 10) });
+}
+
+function getUserFeedbackPreferenceKey (username: string): string {
+    return `userFeedbackPreference:${username}`;
+}
+
+async function getUserFeedbackPreference (username: string, context: TriggerContext): Promise<boolean> {
+    const value = await context.redis.get(getUserFeedbackPreferenceKey(username));
+    return value === "true";
+}
+
+async function setUserFeedbackPreference (username: string, preference: boolean, context: TriggerContext) {
+    await context.redis.set(getUserFeedbackPreferenceKey(username), JSON.stringify(preference), { expiration: addDays(new Date(), 28) });
+}
+
+export async function handleReportUser (event: MenuItemOnPressEvent, context: Context) {
+    const target = await getPostOrCommentById(context.reddit, event.targetId);
+    if (context.subredditName === CONTROL_SUBREDDIT) {
+        await handleControlSubReportUser(target, context);
+        return;
+    }
+
+    const controlSubSettings = await getControlSubSettings(context);
+    if (!controlSubSettings.allowNewSubmissions) {
+        context.ui.showToast("Bot Bouncer is not currently accepting new submissions.");
+        return;
+    }
+
+    const currentStatus = await getUserStatus(target.authorName, context);
+    if (currentStatus) {
+        const queryableStatuses = [UserStatus.Organic, UserStatus.Service];
+        if (queryableStatuses.includes(currentStatus.userStatus) && controlSubSettings.allowClassificationQueries) {
+            context.ui.showForm(queryForm, { username: target.authorName, status: currentStatus.userStatus });
+            return;
+        } else {
+            context.ui.showToast(`${target.authorName} has already been reported to Bot Bouncer with status: ${currentStatus.userStatus}`);
+        }
+
+        return;
+    }
+
+    if (await getAlreadyReported(target.authorName, context)) {
+        context.ui.showToast(`${target.authorName} has already been reported recently.`);
+        return;
+    }
+
+    const currentUser = await context.reddit.getCurrentUser();
+
+    if (!currentUser) {
+        context.ui.showToast("You must be logged in to report users to Bot Bouncer.");
+        return;
+    }
+
+    if (controlSubSettings.reporterBlacklist.includes(currentUser.username)) {
+        context.ui.showToast("You are not currently permitted to submit bots to r/BotBouncer. Please write in to modmail if you believe this is a mistake");
+        return;
+    }
+
+    if (target.authorName === `${context.subredditName}-ModTeam`) {
+        context.ui.showToast("You cannot report the subreddit's -ModTeam user.");
+        return;
+    }
+
+    if (target.authorName === currentUser.username) {
+        context.ui.showToast("You cannot report yourself.");
+        return;
+    }
+
+    const reportingUserStatus = await getUserStatus(currentUser.username, context);
+    if (reportingUserStatus?.userStatus === UserStatus.Banned) {
+        context.ui.showToast("You are currently listed as a bot on r/BotBouncer, so you cannot report other users.");
+        return;
+    }
+
+    if (await isModeratorWithCache(target.authorName, context)) {
+        context.ui.showToast("You cannot report a moderator of this subreddit.");
+        return;
+    }
+
+    if (await isBannedWithCache(currentUser.username, context, CONTROL_SUBREDDIT)) {
+        context.ui.showToast("You are currently banned from r/BotBouncer, so you cannot report other users.");
+        return;
+    }
+
+    const user = await getUserOrUndefined(target.authorName, context);
+
+    if (!user) {
+        context.ui.showToast(`${target.authorName} appears to be shadowbanned or suspended.`);
+        return;
+    }
+
+    const canReceiveFeedback = await canUserReceiveFeedback(currentUser.username, context);
+
+    let configRevisionNotice: string | undefined;
+    try {
+        const currentUserIsControlSubMod = await isModeratorWithCache(currentUser.username, context, CONTROL_SUBREDDIT);
+        if (currentUserIsControlSubMod) {
+            const recentConfigRevisionHit = await getRecentConfigRevisionUserHit(target.authorName, context);
+            if (recentConfigRevisionHit) {
+                const revisionDate = new Date(recentConfigRevisionHit.receipt.createdAt);
+                const changedEvaluatorText = recentConfigRevisionHit.receipt.appliesToAllEvaluators
+                    ? "Shared evaluator variables"
+                    : recentConfigRevisionHit.receipt.changedEvaluatorNames.length > 0
+                        ? recentConfigRevisionHit.receipt.changedEvaluatorNames.join(", ")
+                        : "Unknown evaluator variables";
+                configRevisionNotice = [
+                    "Recent Bot Bouncer config revision context detected.",
+                    `Revision code: ${recentConfigRevisionHit.receipt.code}`,
+                    `Revision saved: ${revisionDate.toISOString()} (${formatTimeSince(revisionDate)} ago)`,
+                    `Changed evaluator context: ${changedEvaluatorText}`,
+                    `Matched evaluator: ${recentConfigRevisionHit.hit.evaluatorName}`,
+                    "Emergency cleanup command:",
+                    `!emergency-cleanup {"code":"${recentConfigRevisionHit.receipt.code}","confirm":true}`,
+                    "This internal receipt code is shown only to Bot Bouncer moderators and should not be copied into public report context.",
+                ].join("\n");
+            }
+        }
+    } catch (error) {
+        console.error(`Report User: Failed to load recent config revision context for ${target.authorName}.`, error);
+    }
+
+    const data = {
+        username: target.authorName,
+<<<<<<< Updated upstream
+        userFeedbackPreference: await getUserFeedbackPreference(currentUser.username, context),
+=======
+        configRevisionNotice,
+>>>>>>> Stashed changes
+        feedbackHelpText: canReceiveFeedback ? "You must be able to receive chat messages from /u/bot-bouncer to receive this notification" : "We've tried to send feedback for you several times but this hasn't worked. Check to make sure you can receive chats from /u/bot-bouncer. This option will return within 24h.",
+        feedbackDisabled: !canReceiveFeedback,
+    };
+
+    context.ui.showForm(reportForm, data);
+}
+
+export async function reportFormHandler (event: FormOnSubmitEvent<JSONObject>, context: Context) {
+    const targetId = context.commentId ?? context.postId;
+    const publicContext = event.values[ReportFormField.PublicContext] as boolean | undefined ?? true;
+    if (!targetId) {
+        context.ui.showToast("Sorry, could not report user.");
+        console.log("Error handling report form", context);
+        return;
+    }
+
+    const target = await getPostOrCommentById(context.reddit, targetId);
+
+    const user = await getUserOrUndefined(target.authorName, context);
+
+    if (!user) {
+        context.ui.showToast(`${target.authorName} appears to be shadowbanned or suspended.`);
+        return;
+    }
+
+    const controlSubSettings = await getControlSubSettings(context);
+    const contentAgeLimit = subMonths(new Date(), controlSubSettings.maxInactivityMonths ?? 3);
+
+    if (target.createdAt < contentAgeLimit) {
+        const userContent = await context.reddit.getCommentsAndPostsByUser({
+            username: target.authorName,
+            limit: 100,
+            sort: "new",
+        }).all();
+
+        if (!userContent.some(item => item.createdAt > contentAgeLimit)) {
+            context.ui.showToast("You can only report users with recent content on their history.");
+            return;
+        }
+    }
+
+    const currentUser = await context.reddit.getCurrentUser();
+    const reportContext = event.values[ReportFormField.ReportContext] as string | undefined;
+
+    await Promise.all([
+        addExternalSubmissionFromClientSub({
+            username: target.authorName,
+            subreddit: context.subredditName,
+            submitter: currentUser?.username,
+            reportContext,
+            publicContext,
+            targetId: target.id,
+            sendFeedback: event.values[ReportFormField.SendFeedback] as boolean | undefined,
+            immediate: true,
+        }, context),
+        recordReportForSummary(target.authorName, context.redis),
+    ]);
+
+    await setAlreadyReported(target.authorName, context);
+
+    context.ui.showToast(`${target.authorName} has been submitted to /r/${CONTROL_SUBREDDIT}. A tracking post will be created shortly.`);
+
+    if (currentUser?.username) {
+        await setUserFeedbackPreference(currentUser.username, event.values[ReportFormField.SendFeedback] as boolean | undefined ?? false, context);
+    }
+}
+
+export const queryFormDefinition: FormFunction = data => ({
+    title: `Query status for ${data.username}`,
+    description: `This user is currently marked as ${data.status}. If you think this is a bot, please tell us why.`,
+    fields: [
+        {
+            type: "paragraph",
+            label: "Please provide more information that might help us understand why this is a bot",
+            lineHeight: 6,
+            name: "queryReason",
+        },
+    ],
+});
+
+export async function queryFormHandler (event: FormOnSubmitEvent<JSONObject>, context: Context) {
+    const currentUser = await context.reddit.getCurrentUsername();
+    if (!currentUser) {
+        context.ui.showToast("You must be logged in to report users to Bot Bouncer.");
+        return;
+    }
+
+    const targetId = context.commentId ?? context.postId;
+    if (!targetId) {
+        context.ui.showToast("Sorry, could not query user.");
+        console.log("Error handling query form", context);
+        return;
+    }
+
+    const target = isLinkId(targetId) ? await context.reddit.getPostById(targetId) : await context.reddit.getCommentById(targetId);
+
+    const queryReason = event.values.queryReason as string | undefined;
+    if (!queryReason || queryReason.trim().length < 10) {
+        context.ui.showToast("Please provide a more detailed reason for your query.");
+        return;
+    }
+
+    await addClassificationQueryToQueue({
+        username: target.authorName,
+        message: queryReason,
+        submittingUser: currentUser,
+    }, context);
+
+    context.ui.showToast(`Your query about ${target.authorName} has been submitted to the Bot Bouncer team.`);
+}

--- a/src/main.ts.bak-conflict
+++ b/src/main.ts.bak-conflict
@@ -8,7 +8,7 @@ import { handleConfigWikiChange, handleModAction, notifyModTeamOnDemod } from ".
 import { handleModmail } from "./modmail/modmail.js";
 import { handleControlSubAccountEvaluation } from "./handleControlSubAccountEvaluation.js";
 import { handleReportUser, queryFormDefinition, queryFormHandler, reportFormDefinition, reportFormHandler } from "./handleReportUser.js";
-import { handleClientCommentUpdate, handleClientPostUpdate } from "./handleClientPostOrComment.js";
+import { handleClientCommentUpdate } from "./handleClientPostOrComment.js";
 import { handleClassificationChanges, processModqueueRemovalStore, queueRecentReclassifications } from "./handleClientSubredditClassificationChanges.js";
 import { handleControlSubPostDelete } from "./handleControlSubPostDelete.js";
 import { updateEvaluatorVariablesFromWikiHandler } from "./userEvaluation/evaluatorVariables.js";
@@ -20,8 +20,13 @@ import { perform6HourlyJobs, perform6HourlyJobsPart2 } from "./scheduler/sixHour
 import { checkUptimeAndMessages } from "./uptimeMonitor.js";
 import { handleRapidJob } from "./scheduler/handleRapidJob.js";
 import { buildEvaluatorAccuracyStatistics } from "./statistics/evaluatorAccuracyStatistics.js";
-import { gatherDefinedHandlesStats, storeDefinedHandlesDataJob } from "./statistics/definedHandlesStatistics.js";
+<<<<<<< Updated upstream
+import { definedHandlesStatsInitializer, gatherDefinedHandlesStats, storeDefinedHandlesDataJob } from "./statistics/definedHandlesStatistics.js";
 import { deleteRecordsForRemovedUsers, classificationReversalsJob, reversePostCreationQueue } from "./modmail/evaluatorReversals.js";
+=======
+import { gatherDefinedHandlesStats, storeDefinedHandlesDataJob } from "./statistics/definedHandlesStatistics.js";
+import { deleteRecordsForRemovedUsers, classificationReversalsJob, reversePostCreationQueue, emergencyConfigCleanupJob } from "./modmail/evaluatorReversals.js";
+>>>>>>> Stashed changes
 import { handleCommentCreate, handlePostCreate, handlePostSubmit } from "./handleContentCreation.js";
 import { conditionalStatsUpdate } from "./statistics/conditionalStatsUpdate.js";
 import { asyncWikiUpdate } from "./statistics/asyncWikiUpdate.js";
@@ -65,11 +70,6 @@ Devvit.addTrigger({
 Devvit.addTrigger({
     event: "CommentUpdate",
     onEvent: handleClientCommentUpdate,
-});
-
-Devvit.addTrigger({
-    event: "PostUpdate",
-    onEvent: handleClientPostUpdate,
 });
 
 Devvit.addTrigger({
@@ -160,6 +160,11 @@ Devvit.addSchedulerJob({
 });
 
 Devvit.addSchedulerJob({
+    name: ControlSubredditJob.DefinedHandlesStatisticsInitialiser,
+    onRun: definedHandlesStatsInitializer,
+});
+
+Devvit.addSchedulerJob({
     name: ControlSubredditJob.QueueKarmaFarmingSubs,
     onRun: queueKarmaFarmingSubs,
 });
@@ -202,6 +207,11 @@ Devvit.addSchedulerJob({
 Devvit.addSchedulerJob({
     name: ControlSubredditJob.PostCreationQueueReversals,
     onRun: reversePostCreationQueue,
+});
+
+Devvit.addSchedulerJob({
+    name: ControlSubredditJob.EmergencyConfigCleanup,
+    onRun: emergencyConfigCleanupJob,
 });
 
 Devvit.addSchedulerJob({

--- a/src/modmail/evaluatorReversals.ts.bak-conflict
+++ b/src/modmail/evaluatorReversals.ts.bak-conflict
@@ -1,0 +1,713 @@
+import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext, WikiPagePermissionLevel } from "@devvit/public-api";
+import { deleteUserStatus, getUserStatus, updateAggregate, UserStatus } from "../dataStore.js";
+import { addDays, addMinutes, addSeconds, format } from "date-fns";
+import { CONTROL_SUBREDDIT, ControlSubredditJob, PostFlairTemplate } from "../constants.js";
+import { deleteAccountInitialEvaluationResults, getAccountInitialEvaluationResults } from "../handleControlSubAccountEvaluation.js";
+import { CLEANUP_LOG_KEY } from "../cleanup.js";
+import { ModmailMessage } from "./modmail.js";
+import Ajv, { JSONSchemaType } from "ajv";
+import { AsyncSubmission } from "../postCreation.js";
+import pluralize from "pluralize";
+import json2md from "json2md";
+<<<<<<< Updated upstream
+=======
+import { getConfigRevisionReceipt } from "../configRevisionReceipts.js";
+>>>>>>> Stashed changes
+
+const REVERSED_USERS = "ReversedUsers";
+
+export async function addToReversalsQueue (username: string, days: number, context: TriggerContext) {
+    const removalDate = addDays(new Date(), days).getTime();
+    await context.redis.zAdd(REVERSED_USERS, { member: username, score: removalDate });
+}
+
+export async function removeUserFromReversalsQueue (username: string, context: TriggerContext) {
+    const removedItems = await context.redis.zRem(REVERSED_USERS, [username]);
+    if (removedItems > 0) {
+        console.log(`Reversals Queue: Removed ${username} from reversals queue.`);
+    }
+}
+
+export async function handleReversalCommand (message: ModmailMessage, context: TriggerContext) {
+    if (context.subredditName !== CONTROL_SUBREDDIT) {
+        throw new Error("Reversal commands can only be handled in the control subreddit.");
+    }
+
+    if (message.bodyMarkdown.startsWith("!reverse-classification")) {
+        await reverseExtract(message, context);
+    }
+
+    if (message.bodyMarkdown.startsWith("!reverse-postqueue {")) {
+        await reverseQueue(message, context);
+    }
+}
+
+async function reverseExtract (message: ModmailMessage, context: TriggerContext) {
+    const regex = /!reverse-classification (\w{4})/;
+    const match = regex.exec(message.bodyMarkdown);
+
+    const identifier = match ? match[1] : undefined;
+    if (!identifier) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Could not find a valid reversal command in your message. Please ensure you include the correct command.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const reversibleData = await context.redis.get(`reversibleExtract:${identifier}`);
+    if (!reversibleData) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ The reversal command has expired or is invalid. Reversals commands are only valid for two hours after the extract is generated.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const users = JSON.parse(reversibleData) as string[];
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.ClassificationReversals,
+        runAt: addSeconds(new Date(), 10),
+        data: {
+            firstRun: true,
+            usersToReverse: users,
+            reversedTotal: 0,
+            conversationId: message.conversationId,
+        },
+    });
+
+    await context.reddit.modMail.reply({
+        conversationId: message.conversationId,
+        body: `Scheduled reversal of classifications for ${users.length} ${pluralize("user", users.length)}. You will receive a confirmation message when the process is complete. Note - large reversal batches are done slowly to ensure that subreddits pick up on new classifications.`,
+        isInternal: true,
+    });
+}
+
+export async function classificationReversalsJob (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
+    const usersToReverse = event.data?.usersToReverse as string[] | undefined ?? [];
+    const conversationId = event.data?.conversationId as string | undefined;
+    let reversedTotal = event.data?.reversedTotal as number | undefined ?? 0;
+
+    if (!conversationId) {
+        throw new Error("Classification reversals job must be run with a conversation ID.");
+    }
+
+    if (usersToReverse.length === 0 && conversationId) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `✅ Completed reversals. A total of ${reversedTotal} ${pluralize("user", reversedTotal)} had their classifications reversed.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    const runLimit = addSeconds(new Date(), 10);
+    let reversedInBatch = 0;
+
+    while (usersToReverse.length > 0 && reversedInBatch < 100 && new Date() < runLimit) {
+        const username = usersToReverse.shift();
+        if (!username) {
+            break;
+        }
+
+        const userStatus = await getUserStatus(username, context);
+        if (userStatus?.userStatus !== UserStatus.Banned) {
+            continue;
+        }
+
+        if (userStatus.trackingPostId) {
+            await context.reddit.setPostFlair({
+                subredditName: CONTROL_SUBREDDIT,
+                postId: userStatus.trackingPostId,
+                flairTemplateId: PostFlairTemplate.Organic,
+            });
+            await addToReversalsQueue(username, 7, context);
+
+            reversedTotal++;
+            reversedInBatch++;
+        }
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.ClassificationReversals,
+        runAt: addMinutes(new Date(), 1),
+        data: {
+            usersToReverse,
+            conversationId,
+            reversedTotal,
+        },
+    });
+}
+
+
+interface EmergencyCleanupData {
+    code: string;
+    confirm?: boolean;
+    dryRun?: boolean;
+}
+
+const emergencyCleanupSchema: JSONSchemaType<EmergencyCleanupData> = {
+    type: "object",
+    properties: {
+        code: { type: "string" },
+        confirm: { type: "boolean", nullable: true },
+        dryRun: { type: "boolean", nullable: true },
+    },
+    required: ["code"],
+    additionalProperties: false,
+};
+
+function getEmergencyCleanupMatchesKey (cleanupId: string): string {
+    return `emergencyCleanupMatches:${cleanupId}`;
+}
+
+function getEmergencyCleanupRevisionText (receipt: Awaited<ReturnType<typeof getConfigRevisionReceipt>>): string {
+    if (!receipt) {
+        return "Unknown";
+    }
+
+    if (receipt.appliesToAllEvaluators) {
+        return "Shared evaluator variables";
+    }
+
+    if (receipt.changedEvaluatorNames.length > 0) {
+        return receipt.changedEvaluatorNames.join(", ");
+    }
+
+    return "Unknown evaluator variables";
+}
+
+export async function handleEmergencyCleanupCommand (message: ModmailMessage, context: TriggerContext) {
+    if (context.subredditName !== CONTROL_SUBREDDIT) {
+        throw new Error("Emergency cleanup commands can only be handled in the control subreddit.");
+    }
+
+    if (!message.bodyMarkdown.startsWith("!emergency-cleanup {")) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid command format. Use `!emergency-cleanup {\"code\":\"REVISION-CODE\",\"confirm\":true}` or `!emergency-cleanup {\"code\":\"REVISION-CODE\",\"dryRun\":true}`.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    let data: EmergencyCleanupData;
+    try {
+        data = JSON.parse(message.bodyMarkdown.replace("!emergency-cleanup ", "")) as EmergencyCleanupData;
+    } catch {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid JSON format for the emergency-cleanup command.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const ajv = new Ajv.default();
+    const validate = ajv.compile(emergencyCleanupSchema);
+    if (!validate(data)) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: `❌ Invalid data for the emergency-cleanup command: ${ajv.errorsText(validate.errors)}`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (!data.confirm && !data.dryRun) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Emergency cleanup requires either `confirm: true` or `dryRun: true`. No changes were made.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const receipt = await getConfigRevisionReceipt(data.code, context);
+    if (!receipt) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ The revision code was not found. It may be invalid or expired.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const cleanupId = Date.now().toString();
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.EmergencyConfigCleanup,
+        runAt: new Date(),
+        data: {
+            firstRun: true,
+            cleanupId,
+            code: data.code,
+            dryRun: data.dryRun === true,
+            conversationId: message.conversationId,
+            runBy: message.messageAuthor,
+            matchedTotal: 0,
+            removedTotal: 0,
+            invalidTotal: 0,
+        },
+    });
+
+    await context.reddit.modMail.reply({
+        conversationId: message.conversationId,
+        body: `${data.dryRun ? "Dry-run" : "Emergency cleanup"} scheduled for revision code ${data.code}. Bot Bouncer will reply with the extraction and cleanup report when complete.`,
+        isInternal: true,
+    });
+}
+
+export async function emergencyConfigCleanupJob (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
+    const conversationId = event.data?.conversationId as string | undefined;
+    const cleanupId = event.data?.cleanupId as string | undefined;
+    const code = event.data?.code as string | undefined;
+    const dryRun = event.data?.dryRun as boolean | undefined ?? false;
+    const runBy = event.data?.runBy as string | undefined ?? "unknown";
+    let matchedTotal = event.data?.matchedTotal as number | undefined ?? 0;
+    let removedTotal = event.data?.removedTotal as number | undefined ?? 0;
+    let invalidTotal = event.data?.invalidTotal as number | undefined ?? 0;
+
+    if (!conversationId || !cleanupId || !code) {
+        throw new Error("Emergency config cleanup job must be run with conversationId, cleanupId, and code.");
+    }
+
+    const receipt = await getConfigRevisionReceipt(code, context);
+    if (!receipt) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `❌ Emergency cleanup failed because revision code ${code} was not found.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (event.data?.firstRun) {
+        console.log(`Emergency Cleanup: Starting ${dryRun ? "dry-run" : "cleanup"} for config revision ${code}.`);
+        const submissionQueue = await context.redis.zRange(SUBMISSION_QUEUE, 0, -1);
+        await context.redis.del(getEmergencyCleanupMatchesKey(cleanupId));
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.EmergencyConfigCleanup,
+            runAt: new Date(),
+            data: {
+                firstRun: false,
+                cleanupId,
+                code,
+                dryRun,
+                queueUsers: submissionQueue.map(entry => entry.member),
+                conversationId,
+                runBy,
+                matchedTotal,
+                removedTotal,
+                invalidTotal,
+            },
+        });
+        return;
+    }
+
+    const runLimit = addSeconds(new Date(), 10);
+    const queueUsers = event.data?.queueUsers as string[] | undefined ?? [];
+
+    if (queueUsers.length === 0) {
+        const wikiLink = await writeEmergencyCleanupExtract(cleanupId, code, receipt, conversationId, dryRun, runBy, context);
+        await context.redis.del(getEmergencyCleanupMatchesKey(cleanupId));
+
+        const body: string[] = [
+            dryRun ? "✅ Emergency cleanup dry-run completed." : "✅ Emergency cleanup completed.",
+            "",
+            `Revision code: ${code}`,
+            `Revision saved: ${new Date(receipt.createdAt).toISOString()}`,
+            `Changed evaluator context: ${getEmergencyCleanupRevisionText(receipt)}`,
+            `Cleanup run by: u/${runBy}`,
+            "",
+            `Matching queue entries: ${matchedTotal.toLocaleString()}`,
+            dryRun ? "Queue entries removed: 0 (dry run)" : `Queue entries removed: ${removedTotal.toLocaleString()}`,
+        ];
+
+        if (invalidTotal > 0) {
+            body.push(`Queue entries skipped due to unreadable details: ${invalidTotal.toLocaleString()}`);
+        }
+
+        if (wikiLink) {
+            body.push("");
+            body.push(`Data extraction saved before cleanup: ${wikiLink}`);
+        } else {
+            body.push("");
+            body.push("No matching queue entries were found, so no extraction page was written.");
+        }
+
+        if (dryRun && matchedTotal > 0) {
+            body.push("");
+            body.push("To run the cleanup, use:");
+            body.push(`\`!emergency-cleanup {\"code\":\"${code}\",\"confirm\":true}\``);
+        }
+
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: body.join("\n"),
+            isInternal: true,
+        });
+        return;
+    }
+
+    while (queueUsers.length > 0 && new Date() < runLimit) {
+        const username = queueUsers.shift();
+        if (!username) {
+            break;
+        }
+
+        const submissionDetailsRaw = await context.redis.hGet(SUBMISSION_DETAILS, username);
+        if (!submissionDetailsRaw) {
+            continue;
+        }
+
+        let submissionDetails: AsyncSubmission;
+        try {
+            submissionDetails = JSON.parse(submissionDetailsRaw) as AsyncSubmission;
+        } catch {
+            invalidTotal++;
+            continue;
+        }
+
+        if (submissionDetails.configRevisionHit?.revisionCode !== code) {
+            continue;
+        }
+
+        matchedTotal++;
+        await context.redis.hSet(getEmergencyCleanupMatchesKey(cleanupId), { [username]: submissionDetailsRaw });
+        await context.redis.expire(getEmergencyCleanupMatchesKey(cleanupId), 60 * 60);
+
+        if (!dryRun) {
+            const txn = await context.redis.watch();
+            await txn.multi();
+            await txn.zRem(SUBMISSION_QUEUE, [username]);
+            await txn.hDel(SUBMISSION_DETAILS, [username]);
+            await txn.exec();
+            await deleteAccountInitialEvaluationResults(username, context);
+            removedTotal++;
+            console.log(`Emergency Cleanup: Removed ${username} from the post creation queue for config revision ${code}.`);
+        }
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.EmergencyConfigCleanup,
+        runAt: addSeconds(new Date(), 5),
+        data: {
+            firstRun: false,
+            cleanupId,
+            code,
+            dryRun,
+            queueUsers,
+            conversationId,
+            runBy,
+            matchedTotal,
+            removedTotal,
+            invalidTotal,
+        },
+    });
+}
+
+async function writeEmergencyCleanupExtract (
+    cleanupId: string,
+    code: string,
+    receipt: NonNullable<Awaited<ReturnType<typeof getConfigRevisionReceipt>>>,
+    conversationId: string,
+    dryRun: boolean,
+    runBy: string,
+    context: JobContext,
+): Promise<string | undefined> {
+    const rawData = await context.redis.hGetAll(getEmergencyCleanupMatchesKey(cleanupId));
+    const entries = Object.entries(rawData)
+        .map(([username, value]) => ({ username, submission: JSON.parse(value) as AsyncSubmission }))
+        .sort((a, b) => a.username.localeCompare(b.username));
+
+    if (entries.length === 0) {
+        return;
+    }
+
+    if (entries.length > 5000) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `Emergency cleanup matched ${entries.length.toLocaleString()} queue entries. This exceeds the 5,000-user wiki extraction limit, so the detailed table was not written.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    const headers = ["User", "Queued At", "Submitter", "Status", "Matched Evaluator", "Target Subreddit", "Target ID"];
+    const rows = entries.map(entry => {
+        const queueTime = entry.submission.queueTime ?? entry.submission.details.reportedAt;
+        const targetId = entry.submission.configRevisionHit?.targetId ?? "";
+        return [
+            `[${entry.username}](https://www.reddit.com/user/${entry.username})`,
+            queueTime ? format(new Date(queueTime), "yyyy-MM-dd HH:mm") : "",
+            entry.submission.details.submitter ?? entry.submission.submitter ?? "",
+            entry.submission.details.userStatus,
+            entry.submission.configRevisionHit?.evaluatorName ?? "",
+            entry.submission.configRevisionHit?.subreddit ? `/r/${entry.submission.configRevisionHit.subreddit}` : "",
+            targetId ? `https://redd.it/${targetId.substring(3)}` : "",
+        ];
+    });
+
+    const content = json2md([
+        { h1: "Emergency cleanup data extraction" },
+        { p: `Revision code: ${code}` },
+        { p: `Revision saved: ${new Date(receipt.createdAt).toISOString()}` },
+        { p: `Changed evaluator context: ${getEmergencyCleanupRevisionText(receipt)}` },
+        { p: `Cleanup mode: ${dryRun ? "dry run" : "confirmed cleanup"}` },
+        { p: `Cleanup run by: u/${runBy}` },
+        { p: `Matched queued users: ${entries.length.toLocaleString()}` },
+        { table: { headers, rows } },
+    ]);
+
+    const subredditName = context.subredditName ?? CONTROL_SUBREDDIT;
+    const wikiPageName = "emergency-cleanup";
+    let wikiPageExists = true;
+    try {
+        await context.reddit.getWikiPage(subredditName, wikiPageName);
+    } catch {
+        wikiPageExists = false;
+    }
+
+    const result = await context.reddit.updateWikiPage({
+        subredditName,
+        page: wikiPageName,
+        content,
+    });
+
+    if (!wikiPageExists) {
+        await context.reddit.updateWikiPageSettings({
+            subredditName,
+            page: wikiPageName,
+            permLevel: WikiPagePermissionLevel.MODS_ONLY,
+            listed: true,
+        });
+    }
+
+    return `https://www.reddit.com/r/${subredditName}/wiki/${wikiPageName}?v=${result.revisionId}`;
+}
+
+interface PostCreationQueueData {
+    submitter?: string;
+    hitReason?: string;
+    hitReasonRegex?: string;
+}
+
+const schema: JSONSchemaType<PostCreationQueueData> = {
+    type: "object",
+    properties: {
+        submitter: { type: "string", nullable: true },
+        hitReason: { type: "string", nullable: true },
+        hitReasonRegex: { type: "string", nullable: true },
+    },
+    additionalProperties: false,
+};
+
+async function reverseQueue (message: ModmailMessage, context: TriggerContext) {
+    if (!message.bodyMarkdown.startsWith("!reverse-postqueue {")) {
+        return;
+    }
+
+    let data: PostCreationQueueData;
+    try {
+        data = JSON.parse(message.bodyMarkdown.replace("!reverse-postqueue ", "")) as PostCreationQueueData;
+    } catch {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid JSON format for the reverse-postqueue command.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const ajv = new Ajv.default();
+    const validate = ajv.compile(schema);
+    if (!validate(data)) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: `❌ Invalid data for the reverse-postqueue command: ${ajv.errorsText(validate.errors)}`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (!data.submitter && !data.hitReason && !data.hitReasonRegex) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ You must specify at least a submitter, hitReason, or hitReasonRegex to reverse entries in the post creation queue.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.PostCreationQueueReversals,
+        runAt: new Date(),
+        data: {
+            firstRun: true,
+            conversationId: message.conversationId,
+            submitter: data.submitter ?? "",
+            hitReason: data.hitReason ?? "",
+            hitReasonRegex: data.hitReasonRegex ?? "",
+            reversedTotal: 0,
+        },
+    });
+}
+
+const SUBMISSION_QUEUE = "submissionQueue";
+const SUBMISSION_DETAILS = "submissionDetails";
+
+export async function reversePostCreationQueue (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
+    const conversationId = event.data?.conversationId as string | undefined;
+    const submitterFilter = event.data?.submitter as string | undefined ?? "";
+    const hitReasonFilter = event.data?.hitReason as string | undefined ?? "";
+    const hitReasonRegexFilter = event.data?.hitReasonRegex as string | undefined ?? "";
+
+    let reversedTotal = event.data?.reversedTotal as number | undefined ?? 0;
+
+    if (!conversationId) {
+        throw new Error("Post creation queue reversals job must be run with a conversation ID.");
+    }
+
+    if (event.data?.firstRun) {
+        console.log("Evaluator Reversals: Starting post creation queue reversals job.");
+        const submissionQueue = await context.redis.zRange(SUBMISSION_QUEUE, 0, -1);
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.PostCreationQueueReversals,
+            runAt: new Date(),
+            data: {
+                firstRun: false,
+                queueUsers: submissionQueue.map(entry => entry.member),
+                conversationId,
+                submitter: submitterFilter,
+                hitReason: hitReasonFilter,
+                reversedTotal,
+            },
+        });
+        return;
+    }
+
+    const runLimit = addSeconds(new Date(), 10);
+
+    const queueUsers = event.data?.queueUsers as string[] | undefined ?? [];
+    if (queueUsers.length === 0) {
+        const remainingCount = await context.redis.zCard(SUBMISSION_QUEUE);
+        const message: json2md.DataObject[] = [
+            { p: `✅ Completed post creation queue reversals. A total of ${reversedTotal} ${pluralize("user", reversedTotal)} had their entries removed from the post creation queue.` },
+            { p: `There are ${remainingCount} ${pluralize("user", remainingCount)} remaining in the post creation queue.` },
+        ];
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: json2md(message),
+            isInternal: true,
+        });
+        return;
+    }
+
+    while (queueUsers.length > 0 && new Date() < runLimit) {
+        const username = queueUsers.shift();
+        if (!username) {
+            break;
+        }
+
+        const submissionDetailsRaw = await context.redis.hGet(SUBMISSION_DETAILS, username);
+        if (!submissionDetailsRaw) {
+            continue;
+        }
+
+        if (submitterFilter) {
+            const submissionDetails = JSON.parse(submissionDetailsRaw) as AsyncSubmission;
+            if (submissionDetails.details.submitter !== submitterFilter) {
+                continue;
+            }
+        }
+
+        if (hitReasonFilter || hitReasonRegexFilter) {
+            const evaluatorData = await getAccountInitialEvaluationResults(username, context);
+            if (!evaluatorData.some((entry) => {
+                if (!entry.hitReason) {
+                    return false;
+                }
+
+                let hitReason: string;
+                if (typeof entry.hitReason === "string") {
+                    hitReason = entry.hitReason;
+                } else {
+                    hitReason = entry.hitReason.reason;
+                }
+                return hitReason.includes(hitReasonFilter) || (hitReasonRegexFilter && new RegExp(hitReasonRegexFilter).test(hitReason));
+            })) {
+                continue;
+            }
+        }
+
+        // Reversible.
+        await context.redis.zRem(SUBMISSION_QUEUE, [username]);
+        await context.redis.hDel(SUBMISSION_DETAILS, [username]);
+        await deleteAccountInitialEvaluationResults(username, context);
+        console.log(`Evaluator Reversals: Removed ${username} from the post creation queue.`);
+        reversedTotal++;
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.PostCreationQueueReversals,
+        runAt: addSeconds(new Date(), 5),
+        data: {
+            firstRun: false,
+            queueUsers,
+            conversationId,
+            submitter: submitterFilter,
+            hitReason: hitReasonFilter,
+            reversedTotal,
+        },
+    });
+}
+
+export async function deleteRecordsForRemovedUsers (_: unknown, context: JobContext) {
+    const runLimit = addSeconds(new Date(), 15);
+    const removedUsers = await context.redis.zRange(REVERSED_USERS, 0, Date.now(), { by: "score" });
+    if (removedUsers.length === 0) {
+        return;
+    }
+
+    let processedCount = 0;
+    let deletedCount = 0;
+    const processedUsers: string[] = [];
+
+    while (removedUsers.length > 0 && processedCount < 10 && new Date() < runLimit) {
+        const firstEntry = removedUsers.shift();
+        if (!firstEntry) {
+            break;
+        }
+
+        const username = firstEntry.member;
+        processedUsers.push(username);
+        processedCount++;
+
+        const userStatus = await getUserStatus(username, context);
+        if (userStatus?.userStatus !== UserStatus.Organic) {
+            continue;
+        }
+
+        await updateAggregate(userStatus.userStatus, -1, context.redis);
+        await context.redis.zRem(CLEANUP_LOG_KEY, [username]);
+
+        await deleteUserStatus(username, context);
+
+        const post = await context.reddit.getPostById(userStatus.trackingPostId);
+        await post.delete();
+        deletedCount++;
+    }
+
+    console.log(`Delete Records: Processed ${processedCount} users, deleted ${deletedCount} users. ${removedUsers.length} users left in the queue.`);
+    await context.redis.zRem(REVERSED_USERS, processedUsers);
+
+    if (removedUsers.length > 0) {
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.DeleteRecordsForRemovedUsers,
+            runAt: addSeconds(new Date(), 5),
+        });
+    }
+}

--- a/src/modmail/evaluatorReversals.ts.bak-duplicate-json2md
+++ b/src/modmail/evaluatorReversals.ts.bak-duplicate-json2md
@@ -1,0 +1,710 @@
+import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext, WikiPagePermissionLevel } from "@devvit/public-api";
+import { deleteUserStatus, getUserStatus, updateAggregate, UserStatus } from "../dataStore.js";
+import { addDays, addMinutes, addSeconds, format } from "date-fns";
+import { CONTROL_SUBREDDIT, ControlSubredditJob, PostFlairTemplate } from "../constants.js";
+import { deleteAccountInitialEvaluationResults, getAccountInitialEvaluationResults } from "../handleControlSubAccountEvaluation.js";
+import { CLEANUP_LOG_KEY } from "../cleanup.js";
+import { ModmailMessage } from "./modmail.js";
+import Ajv, { JSONSchemaType } from "ajv";
+import { AsyncSubmission } from "../postCreation.js";
+import pluralize from "pluralize";
+import json2md from "json2md";
+import json2md from "json2md";
+import { getConfigRevisionReceipt } from "../configRevisionReceipts.js";
+const REVERSED_USERS = "ReversedUsers";
+
+export async function addToReversalsQueue (username: string, days: number, context: TriggerContext) {
+    const removalDate = addDays(new Date(), days).getTime();
+    await context.redis.zAdd(REVERSED_USERS, { member: username, score: removalDate });
+}
+
+export async function removeUserFromReversalsQueue (username: string, context: TriggerContext) {
+    const removedItems = await context.redis.zRem(REVERSED_USERS, [username]);
+    if (removedItems > 0) {
+        console.log(`Reversals Queue: Removed ${username} from reversals queue.`);
+    }
+}
+
+export async function handleReversalCommand (message: ModmailMessage, context: TriggerContext) {
+    if (context.subredditName !== CONTROL_SUBREDDIT) {
+        throw new Error("Reversal commands can only be handled in the control subreddit.");
+    }
+
+    if (message.bodyMarkdown.startsWith("!reverse-classification")) {
+        await reverseExtract(message, context);
+    }
+
+    if (message.bodyMarkdown.startsWith("!reverse-postqueue {")) {
+        await reverseQueue(message, context);
+    }
+}
+
+async function reverseExtract (message: ModmailMessage, context: TriggerContext) {
+    const regex = /!reverse-classification (\w{4})/;
+    const match = regex.exec(message.bodyMarkdown);
+
+    const identifier = match ? match[1] : undefined;
+    if (!identifier) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Could not find a valid reversal command in your message. Please ensure you include the correct command.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const reversibleData = await context.redis.get(`reversibleExtract:${identifier}`);
+    if (!reversibleData) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ The reversal command has expired or is invalid. Reversals commands are only valid for two hours after the extract is generated.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const users = JSON.parse(reversibleData) as string[];
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.ClassificationReversals,
+        runAt: addSeconds(new Date(), 10),
+        data: {
+            firstRun: true,
+            usersToReverse: users,
+            reversedTotal: 0,
+            conversationId: message.conversationId,
+        },
+    });
+
+    await context.reddit.modMail.reply({
+        conversationId: message.conversationId,
+        body: `Scheduled reversal of classifications for ${users.length} ${pluralize("user", users.length)}. You will receive a confirmation message when the process is complete. Note - large reversal batches are done slowly to ensure that subreddits pick up on new classifications.`,
+        isInternal: true,
+    });
+}
+
+export async function classificationReversalsJob (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
+    const usersToReverse = event.data?.usersToReverse as string[] | undefined ?? [];
+    const conversationId = event.data?.conversationId as string | undefined;
+    let reversedTotal = event.data?.reversedTotal as number | undefined ?? 0;
+
+    if (!conversationId) {
+        throw new Error("Classification reversals job must be run with a conversation ID.");
+    }
+
+    if (usersToReverse.length === 0 && conversationId) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `✅ Completed reversals. A total of ${reversedTotal} ${pluralize("user", reversedTotal)} had their classifications reversed.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    const runLimit = addSeconds(new Date(), 10);
+    let reversedInBatch = 0;
+
+    while (usersToReverse.length > 0 && reversedInBatch < 100 && new Date() < runLimit) {
+        const username = usersToReverse.shift();
+        if (!username) {
+            break;
+        }
+
+        const userStatus = await getUserStatus(username, context);
+        if (userStatus?.userStatus !== UserStatus.Banned) {
+            continue;
+        }
+
+        if (userStatus.trackingPostId) {
+            await context.reddit.setPostFlair({
+                subredditName: CONTROL_SUBREDDIT,
+                postId: userStatus.trackingPostId,
+                flairTemplateId: PostFlairTemplate.Organic,
+            });
+            await addToReversalsQueue(username, 7, context);
+
+            reversedTotal++;
+            reversedInBatch++;
+        }
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.ClassificationReversals,
+        runAt: addMinutes(new Date(), 1),
+        data: {
+            usersToReverse,
+            conversationId,
+            reversedTotal,
+        },
+    });
+}
+
+
+interface EmergencyCleanupData {
+    code: string;
+    confirm?: boolean;
+    dryRun?: boolean;
+}
+
+const emergencyCleanupSchema: JSONSchemaType<EmergencyCleanupData> = {
+    type: "object",
+    properties: {
+        code: { type: "string" },
+        confirm: { type: "boolean", nullable: true },
+        dryRun: { type: "boolean", nullable: true },
+    },
+    required: ["code"],
+    additionalProperties: false,
+};
+
+function getEmergencyCleanupMatchesKey (cleanupId: string): string {
+    return `emergencyCleanupMatches:${cleanupId}`;
+}
+
+function getEmergencyCleanupRevisionText (receipt: Awaited<ReturnType<typeof getConfigRevisionReceipt>>): string {
+    if (!receipt) {
+        return "Unknown";
+    }
+
+    if (receipt.appliesToAllEvaluators) {
+        return "Shared evaluator variables";
+    }
+
+    if (receipt.changedEvaluatorNames.length > 0) {
+        return receipt.changedEvaluatorNames.join(", ");
+    }
+
+    return "Unknown evaluator variables";
+}
+
+export async function handleEmergencyCleanupCommand (message: ModmailMessage, context: TriggerContext) {
+    if (context.subredditName !== CONTROL_SUBREDDIT) {
+        throw new Error("Emergency cleanup commands can only be handled in the control subreddit.");
+    }
+
+    if (!message.bodyMarkdown.startsWith("!emergency-cleanup {")) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid command format. Use `!emergency-cleanup {\"code\":\"REVISION-CODE\",\"confirm\":true}` or `!emergency-cleanup {\"code\":\"REVISION-CODE\",\"dryRun\":true}`.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    let data: EmergencyCleanupData;
+    try {
+        data = JSON.parse(message.bodyMarkdown.replace("!emergency-cleanup ", "")) as EmergencyCleanupData;
+    } catch {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid JSON format for the emergency-cleanup command.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const ajv = new Ajv.default();
+    const validate = ajv.compile(emergencyCleanupSchema);
+    if (!validate(data)) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: `❌ Invalid data for the emergency-cleanup command: ${ajv.errorsText(validate.errors)}`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (!data.confirm && !data.dryRun) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Emergency cleanup requires either `confirm: true` or `dryRun: true`. No changes were made.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const receipt = await getConfigRevisionReceipt(data.code, context);
+    if (!receipt) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ The revision code was not found. It may be invalid or expired.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const cleanupId = Date.now().toString();
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.EmergencyConfigCleanup,
+        runAt: new Date(),
+        data: {
+            firstRun: true,
+            cleanupId,
+            code: data.code,
+            dryRun: data.dryRun === true,
+            conversationId: message.conversationId,
+            runBy: message.messageAuthor,
+            matchedTotal: 0,
+            removedTotal: 0,
+            invalidTotal: 0,
+        },
+    });
+
+    await context.reddit.modMail.reply({
+        conversationId: message.conversationId,
+        body: `${data.dryRun ? "Dry-run" : "Emergency cleanup"} scheduled for revision code ${data.code}. Bot Bouncer will reply with the extraction and cleanup report when complete.`,
+        isInternal: true,
+    });
+}
+
+export async function emergencyConfigCleanupJob (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
+    const conversationId = event.data?.conversationId as string | undefined;
+    const cleanupId = event.data?.cleanupId as string | undefined;
+    const code = event.data?.code as string | undefined;
+    const dryRun = event.data?.dryRun as boolean | undefined ?? false;
+    const runBy = event.data?.runBy as string | undefined ?? "unknown";
+    let matchedTotal = event.data?.matchedTotal as number | undefined ?? 0;
+    let removedTotal = event.data?.removedTotal as number | undefined ?? 0;
+    let invalidTotal = event.data?.invalidTotal as number | undefined ?? 0;
+
+    if (!conversationId || !cleanupId || !code) {
+        throw new Error("Emergency config cleanup job must be run with conversationId, cleanupId, and code.");
+    }
+
+    const receipt = await getConfigRevisionReceipt(code, context);
+    if (!receipt) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `❌ Emergency cleanup failed because revision code ${code} was not found.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (event.data?.firstRun) {
+        console.log(`Emergency Cleanup: Starting ${dryRun ? "dry-run" : "cleanup"} for config revision ${code}.`);
+        const submissionQueue = await context.redis.zRange(SUBMISSION_QUEUE, 0, -1);
+        await context.redis.del(getEmergencyCleanupMatchesKey(cleanupId));
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.EmergencyConfigCleanup,
+            runAt: new Date(),
+            data: {
+                firstRun: false,
+                cleanupId,
+                code,
+                dryRun,
+                queueUsers: submissionQueue.map(entry => entry.member),
+                conversationId,
+                runBy,
+                matchedTotal,
+                removedTotal,
+                invalidTotal,
+            },
+        });
+        return;
+    }
+
+    const runLimit = addSeconds(new Date(), 10);
+    const queueUsers = event.data?.queueUsers as string[] | undefined ?? [];
+
+    if (queueUsers.length === 0) {
+        const wikiLink = await writeEmergencyCleanupExtract(cleanupId, code, receipt, conversationId, dryRun, runBy, context);
+        await context.redis.del(getEmergencyCleanupMatchesKey(cleanupId));
+
+        const body: string[] = [
+            dryRun ? "✅ Emergency cleanup dry-run completed." : "✅ Emergency cleanup completed.",
+            "",
+            `Revision code: ${code}`,
+            `Revision saved: ${new Date(receipt.createdAt).toISOString()}`,
+            `Changed evaluator context: ${getEmergencyCleanupRevisionText(receipt)}`,
+            `Cleanup run by: u/${runBy}`,
+            "",
+            `Matching queue entries: ${matchedTotal.toLocaleString()}`,
+            dryRun ? "Queue entries removed: 0 (dry run)" : `Queue entries removed: ${removedTotal.toLocaleString()}`,
+        ];
+
+        if (invalidTotal > 0) {
+            body.push(`Queue entries skipped due to unreadable details: ${invalidTotal.toLocaleString()}`);
+        }
+
+        if (wikiLink) {
+            body.push("");
+            body.push(`Data extraction saved before cleanup: ${wikiLink}`);
+        } else {
+            body.push("");
+            body.push("No matching queue entries were found, so no extraction page was written.");
+        }
+
+        if (dryRun && matchedTotal > 0) {
+            body.push("");
+            body.push("To run the cleanup, use:");
+            body.push(`\`!emergency-cleanup {\"code\":\"${code}\",\"confirm\":true}\``);
+        }
+
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: body.join("\n"),
+            isInternal: true,
+        });
+        return;
+    }
+
+    while (queueUsers.length > 0 && new Date() < runLimit) {
+        const username = queueUsers.shift();
+        if (!username) {
+            break;
+        }
+
+        const submissionDetailsRaw = await context.redis.hGet(SUBMISSION_DETAILS, username);
+        if (!submissionDetailsRaw) {
+            continue;
+        }
+
+        let submissionDetails: AsyncSubmission;
+        try {
+            submissionDetails = JSON.parse(submissionDetailsRaw) as AsyncSubmission;
+        } catch {
+            invalidTotal++;
+            continue;
+        }
+
+        if (submissionDetails.configRevisionHit?.revisionCode !== code) {
+            continue;
+        }
+
+        matchedTotal++;
+        await context.redis.hSet(getEmergencyCleanupMatchesKey(cleanupId), { [username]: submissionDetailsRaw });
+        await context.redis.expire(getEmergencyCleanupMatchesKey(cleanupId), 60 * 60);
+
+        if (!dryRun) {
+            const txn = await context.redis.watch();
+            await txn.multi();
+            await txn.zRem(SUBMISSION_QUEUE, [username]);
+            await txn.hDel(SUBMISSION_DETAILS, [username]);
+            await txn.exec();
+            await deleteAccountInitialEvaluationResults(username, context);
+            removedTotal++;
+            console.log(`Emergency Cleanup: Removed ${username} from the post creation queue for config revision ${code}.`);
+        }
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.EmergencyConfigCleanup,
+        runAt: addSeconds(new Date(), 5),
+        data: {
+            firstRun: false,
+            cleanupId,
+            code,
+            dryRun,
+            queueUsers,
+            conversationId,
+            runBy,
+            matchedTotal,
+            removedTotal,
+            invalidTotal,
+        },
+    });
+}
+
+async function writeEmergencyCleanupExtract (
+    cleanupId: string,
+    code: string,
+    receipt: NonNullable<Awaited<ReturnType<typeof getConfigRevisionReceipt>>>,
+    conversationId: string,
+    dryRun: boolean,
+    runBy: string,
+    context: JobContext,
+): Promise<string | undefined> {
+    const rawData = await context.redis.hGetAll(getEmergencyCleanupMatchesKey(cleanupId));
+    const entries = Object.entries(rawData)
+        .map(([username, value]) => ({ username, submission: JSON.parse(value) as AsyncSubmission }))
+        .sort((a, b) => a.username.localeCompare(b.username));
+
+    if (entries.length === 0) {
+        return;
+    }
+
+    if (entries.length > 5000) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `Emergency cleanup matched ${entries.length.toLocaleString()} queue entries. This exceeds the 5,000-user wiki extraction limit, so the detailed table was not written.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    const headers = ["User", "Queued At", "Submitter", "Status", "Matched Evaluator", "Target Subreddit", "Target ID"];
+    const rows = entries.map(entry => {
+        const queueTime = entry.submission.queueTime ?? entry.submission.details.reportedAt;
+        const targetId = entry.submission.configRevisionHit?.targetId ?? "";
+        return [
+            `[${entry.username}](https://www.reddit.com/user/${entry.username})`,
+            queueTime ? format(new Date(queueTime), "yyyy-MM-dd HH:mm") : "",
+            entry.submission.details.submitter ?? entry.submission.submitter ?? "",
+            entry.submission.details.userStatus,
+            entry.submission.configRevisionHit?.evaluatorName ?? "",
+            entry.submission.configRevisionHit?.subreddit ? `/r/${entry.submission.configRevisionHit.subreddit}` : "",
+            targetId ? `https://redd.it/${targetId.substring(3)}` : "",
+        ];
+    });
+
+    const content = json2md([
+        { h1: "Emergency cleanup data extraction" },
+        { p: `Revision code: ${code}` },
+        { p: `Revision saved: ${new Date(receipt.createdAt).toISOString()}` },
+        { p: `Changed evaluator context: ${getEmergencyCleanupRevisionText(receipt)}` },
+        { p: `Cleanup mode: ${dryRun ? "dry run" : "confirmed cleanup"}` },
+        { p: `Cleanup run by: u/${runBy}` },
+        { p: `Matched queued users: ${entries.length.toLocaleString()}` },
+        { table: { headers, rows } },
+    ]);
+
+    const subredditName = context.subredditName ?? CONTROL_SUBREDDIT;
+    const wikiPageName = "emergency-cleanup";
+    let wikiPageExists = true;
+    try {
+        await context.reddit.getWikiPage(subredditName, wikiPageName);
+    } catch {
+        wikiPageExists = false;
+    }
+
+    const result = await context.reddit.updateWikiPage({
+        subredditName,
+        page: wikiPageName,
+        content,
+    });
+
+    if (!wikiPageExists) {
+        await context.reddit.updateWikiPageSettings({
+            subredditName,
+            page: wikiPageName,
+            permLevel: WikiPagePermissionLevel.MODS_ONLY,
+            listed: true,
+        });
+    }
+
+    return `https://www.reddit.com/r/${subredditName}/wiki/${wikiPageName}?v=${result.revisionId}`;
+}
+
+interface PostCreationQueueData {
+    submitter?: string;
+    hitReason?: string;
+    hitReasonRegex?: string;
+}
+
+const schema: JSONSchemaType<PostCreationQueueData> = {
+    type: "object",
+    properties: {
+        submitter: { type: "string", nullable: true },
+        hitReason: { type: "string", nullable: true },
+        hitReasonRegex: { type: "string", nullable: true },
+    },
+    additionalProperties: false,
+};
+
+async function reverseQueue (message: ModmailMessage, context: TriggerContext) {
+    if (!message.bodyMarkdown.startsWith("!reverse-postqueue {")) {
+        return;
+    }
+
+    let data: PostCreationQueueData;
+    try {
+        data = JSON.parse(message.bodyMarkdown.replace("!reverse-postqueue ", "")) as PostCreationQueueData;
+    } catch {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid JSON format for the reverse-postqueue command.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const ajv = new Ajv.default();
+    const validate = ajv.compile(schema);
+    if (!validate(data)) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: `❌ Invalid data for the reverse-postqueue command: ${ajv.errorsText(validate.errors)}`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (!data.submitter && !data.hitReason && !data.hitReasonRegex) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ You must specify at least a submitter, hitReason, or hitReasonRegex to reverse entries in the post creation queue.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.PostCreationQueueReversals,
+        runAt: new Date(),
+        data: {
+            firstRun: true,
+            conversationId: message.conversationId,
+            submitter: data.submitter ?? "",
+            hitReason: data.hitReason ?? "",
+            hitReasonRegex: data.hitReasonRegex ?? "",
+            reversedTotal: 0,
+        },
+    });
+}
+
+const SUBMISSION_QUEUE = "submissionQueue";
+const SUBMISSION_DETAILS = "submissionDetails";
+
+export async function reversePostCreationQueue (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
+    const conversationId = event.data?.conversationId as string | undefined;
+    const submitterFilter = event.data?.submitter as string | undefined ?? "";
+    const hitReasonFilter = event.data?.hitReason as string | undefined ?? "";
+    const hitReasonRegexFilter = event.data?.hitReasonRegex as string | undefined ?? "";
+
+    let reversedTotal = event.data?.reversedTotal as number | undefined ?? 0;
+
+    if (!conversationId) {
+        throw new Error("Post creation queue reversals job must be run with a conversation ID.");
+    }
+
+    if (event.data?.firstRun) {
+        console.log("Evaluator Reversals: Starting post creation queue reversals job.");
+        const submissionQueue = await context.redis.zRange(SUBMISSION_QUEUE, 0, -1);
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.PostCreationQueueReversals,
+            runAt: new Date(),
+            data: {
+                firstRun: false,
+                queueUsers: submissionQueue.map(entry => entry.member),
+                conversationId,
+                submitter: submitterFilter,
+                hitReason: hitReasonFilter,
+                reversedTotal,
+            },
+        });
+        return;
+    }
+
+    const runLimit = addSeconds(new Date(), 10);
+
+    const queueUsers = event.data?.queueUsers as string[] | undefined ?? [];
+    if (queueUsers.length === 0) {
+        const remainingCount = await context.redis.zCard(SUBMISSION_QUEUE);
+        const message: json2md.DataObject[] = [
+            { p: `✅ Completed post creation queue reversals. A total of ${reversedTotal} ${pluralize("user", reversedTotal)} had their entries removed from the post creation queue.` },
+            { p: `There are ${remainingCount} ${pluralize("user", remainingCount)} remaining in the post creation queue.` },
+        ];
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: json2md(message),
+            isInternal: true,
+        });
+        return;
+    }
+
+    while (queueUsers.length > 0 && new Date() < runLimit) {
+        const username = queueUsers.shift();
+        if (!username) {
+            break;
+        }
+
+        const submissionDetailsRaw = await context.redis.hGet(SUBMISSION_DETAILS, username);
+        if (!submissionDetailsRaw) {
+            continue;
+        }
+
+        if (submitterFilter) {
+            const submissionDetails = JSON.parse(submissionDetailsRaw) as AsyncSubmission;
+            if (submissionDetails.details.submitter !== submitterFilter) {
+                continue;
+            }
+        }
+
+        if (hitReasonFilter || hitReasonRegexFilter) {
+            const evaluatorData = await getAccountInitialEvaluationResults(username, context);
+            if (!evaluatorData.some((entry) => {
+                if (!entry.hitReason) {
+                    return false;
+                }
+
+                let hitReason: string;
+                if (typeof entry.hitReason === "string") {
+                    hitReason = entry.hitReason;
+                } else {
+                    hitReason = entry.hitReason.reason;
+                }
+                return hitReason.includes(hitReasonFilter) || (hitReasonRegexFilter && new RegExp(hitReasonRegexFilter).test(hitReason));
+            })) {
+                continue;
+            }
+        }
+
+        // Reversible.
+        await context.redis.zRem(SUBMISSION_QUEUE, [username]);
+        await context.redis.hDel(SUBMISSION_DETAILS, [username]);
+        await deleteAccountInitialEvaluationResults(username, context);
+        console.log(`Evaluator Reversals: Removed ${username} from the post creation queue.`);
+        reversedTotal++;
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.PostCreationQueueReversals,
+        runAt: addSeconds(new Date(), 5),
+        data: {
+            firstRun: false,
+            queueUsers,
+            conversationId,
+            submitter: submitterFilter,
+            hitReason: hitReasonFilter,
+            reversedTotal,
+        },
+    });
+}
+
+export async function deleteRecordsForRemovedUsers (_: unknown, context: JobContext) {
+    const runLimit = addSeconds(new Date(), 15);
+    const removedUsers = await context.redis.zRange(REVERSED_USERS, 0, Date.now(), { by: "score" });
+    if (removedUsers.length === 0) {
+        return;
+    }
+
+    let processedCount = 0;
+    let deletedCount = 0;
+    const processedUsers: string[] = [];
+
+    while (removedUsers.length > 0 && processedCount < 10 && new Date() < runLimit) {
+        const firstEntry = removedUsers.shift();
+        if (!firstEntry) {
+            break;
+        }
+
+        const username = firstEntry.member;
+        processedUsers.push(username);
+        processedCount++;
+
+        const userStatus = await getUserStatus(username, context);
+        if (userStatus?.userStatus !== UserStatus.Organic) {
+            continue;
+        }
+
+        await updateAggregate(userStatus.userStatus, -1, context.redis);
+        await context.redis.zRem(CLEANUP_LOG_KEY, [username]);
+
+        await deleteUserStatus(username, context);
+
+        const post = await context.reddit.getPostById(userStatus.trackingPostId);
+        await post.delete();
+        deletedCount++;
+    }
+
+    console.log(`Delete Records: Processed ${processedCount} users, deleted ${deletedCount} users. ${removedUsers.length} users left in the queue.`);
+    await context.redis.zRem(REVERSED_USERS, processedUsers);
+
+    if (removedUsers.length > 0) {
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.DeleteRecordsForRemovedUsers,
+            runAt: addSeconds(new Date(), 5),
+        });
+    }
+}

--- a/t
+++ b/t
@@ -1,0 +1,32 @@
+[1mdiff --git a/src/modmail/evaluatorReversals.ts b/src/modmail/evaluatorReversals.ts[m
+[1mindex 73815b9..12b55e1 100644[m
+[1m--- a/src/modmail/evaluatorReversals.ts[m
+[1m+++ b/src/modmail/evaluatorReversals.ts[m
+[36m@@ -287,11 +287,8 @@[m [mexport async function reversePostCreationQueue (event: ScheduledJobEvent<JSONObj[m
+         }[m
+ [m
+         // Reversible.[m
+[31m-        const txn = await context.redis.watch();[m
+[31m-        await txn.multi();[m
+[31m-        await txn.zRem(SUBMISSION_QUEUE, [username]);[m
+[31m-        await txn.hDel(SUBMISSION_DETAILS, [username]);[m
+[31m-        await txn.exec();[m
+[32m+[m[32m        await context.redis.zRem(SUBMISSION_QUEUE, [username]);[m
+[32m+[m[32m        await context.redis.hDel(SUBMISSION_DETAILS, [username]);[m
+         await deleteAccountInitialEvaluationResults(username, context);[m
+         console.log(`Evaluator Reversals: Removed ${username} from the post creation queue.`);[m
+         reversedTotal++;[m
+[36m@@ -337,11 +334,8 @@[m [mexport async function deleteRecordsForRemovedUsers (_: unknown, context: JobCont[m
+             continue;[m
+         }[m
+ [m
+[31m-        const txn = await context.redis.watch();[m
+[31m-        await txn.multi();[m
+[31m-        await updateAggregate(userStatus.userStatus, -1, txn);[m
+[31m-        await txn.zRem(CLEANUP_LOG_KEY, [username]);[m
+[31m-        await txn.exec();[m
+[32m+[m[32m        await updateAggregate(userStatus.userStatus, -1, context.redis);[m
+[32m+[m[32m        await context.redis.zRem(CLEANUP_LOG_KEY, [username]);[m
+ [m
+         await deleteUserStatus(username, context);[m
+ [m

--- a/test-output.txt
+++ b/test-output.txt
@@ -1,0 +1,141 @@
+
+> bot-bouncer@0.0.0 test:unit
+> vitest --run
+
+
+[1m[30m[46m RUN [49m[39m[22m [36mv4.1.9 [39m[90mC:/Users/15738/Documents/Reddit/BotBouncer/repo/bot-bouncer[39m
+
+ [32m✓[39m src/statistics/socialLinksStatistics.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 14[2mms[22m[39m
+ [32m✓[39m src/constants.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 14[2mms[22m[39m
+[90mstderr[2m | src/userEvaluation/evaluatorVariables.test.ts[2m > [22m[2mInvalid regex
+[22m[39mMissing killswitch for Bad Username Bot
+Missing killswitch for Bio Text Bot
+Missing killswitch for Bio Text Defined Handle Bot
+Missing killswitch for Bad Display Name Bot
+Missing killswitch for Bad Display Name Defined Handle Bot
+Missing killswitch for Obfuscated Bio Keywords Bot
+Missing killswitch for Domain Sharer
+Missing killswitch for Sticky Post Title Bot
+Missing killswitch for Self Comment
+Missing killswitch for Bad Post Title Bot
+Missing killswitch for Bad Post Title Defined Handles Bot
+Missing killswitch for Bad Post Title Multi Bot
+Missing killswitch for Suspicious First Post
+Missing killswitch for Inconsistent Age Bot
+Missing killswitch for Inconsistent Gender Bot
+Missing killswitch for World Traveller
+Missing killswitch for Comment Phrase
+Missing killswitch for Telegram Group Bot
+Missing killswitch for Warmup Bot
+Missing killswitch for Social Links Bot
+Missing killswitch for Bot Group Advanced
+Missing killswitch for Title Copy Bot
+Missing killswitch for Bot Group Advanced Internal
+
+[90mstderr[2m | src/userEvaluation/evaluatorVariables.test.ts[2m > [22m[2mRegex with || condition
+[22m[39mMissing killswitch for Bad Username Bot
+Missing killswitch for Bio Text Bot
+Missing killswitch for Bio Text Defined Handle Bot
+Missing killswitch for Bad Display Name Bot
+Missing killswitch for Bad Display Name Defined Handle Bot
+Missing killswitch for Obfuscated Bio Keywords Bot
+Missing killswitch for Domain Sharer
+Missing killswitch for Sticky Post Title Bot
+Missing killswitch for Self Comment
+Missing killswitch for Bad Post Title Bot
+Missing killswitch for Bad Post Title Defined Handles Bot
+Missing killswitch for Bad Post Title Multi Bot
+Missing killswitch for Suspicious First Post
+Missing killswitch for Inconsistent Age Bot
+Missing killswitch for Inconsistent Gender Bot
+Missing killswitch for World Traveller
+Missing killswitch for Comment Phrase
+Missing killswitch for Telegram Group Bot
+Missing killswitch for Warmup Bot
+Missing killswitch for Social Links Bot
+Missing killswitch for Bot Group Advanced
+Missing killswitch for Title Copy Bot
+Missing killswitch for Bot Group Advanced Internal
+
+[90mstdout[2m | src/userEvaluation/evaluatorVariables.test.ts[2m > [22m[2mRegex with || condition
+[22m[39m[
+  {
+    severity: [32m'error'[39m,
+    message: [32m'Bio Text Bot: Bio Text regex is too greedy: (?:addison|adele||allie)'[39m
+  }
+]
+
+[90mstderr[2m | src/userEvaluation/evaluatorVariables.test.ts[2m > [22m[2mRegex with badly formed array
+[22m[39mMissing killswitch for Bad Username Bot
+Missing killswitch for Bio Text Bot
+Missing killswitch for Bio Text Defined Handle Bot
+Missing killswitch for Bad Display Name Bot
+Missing killswitch for Bad Display Name Defined Handle Bot
+Missing killswitch for Obfuscated Bio Keywords Bot
+Missing killswitch for Domain Sharer
+Missing killswitch for Sticky Post Title Bot
+Missing killswitch for Self Comment
+Missing killswitch for Bad Post Title Bot
+Missing killswitch for Bad Post Title Defined Handles Bot
+Missing killswitch for Bad Post Title Multi Bot
+Missing killswitch for Suspicious First Post
+Missing killswitch for Inconsistent Age Bot
+Missing killswitch for Inconsistent Gender Bot
+Missing killswitch for World Traveller
+Missing killswitch for Comment Phrase
+Missing killswitch for Telegram Group Bot
+Missing killswitch for Warmup Bot
+Missing killswitch for Social Links Bot
+Missing killswitch for Bot Group Advanced
+Missing killswitch for Title Copy Bot
+Missing killswitch for Bot Group Advanced Internal
+
+[90mstderr[2m | src/userEvaluation/evaluatorVariables.test.ts[2m > [22m[2mBot Groups test
+[22m[39mMissing killswitch for Bad Username Bot
+Missing killswitch for Bio Text Bot
+Missing killswitch for Bio Text Defined Handle Bot
+Missing killswitch for Bad Display Name Bot
+Missing killswitch for Bad Display Name Defined Handle Bot
+Missing killswitch for Obfuscated Bio Keywords Bot
+Missing killswitch for Domain Sharer
+Missing killswitch for Sticky Post Title Bot
+Missing killswitch for Self Comment
+Missing killswitch for Bad Post Title Bot
+Missing killswitch for Bad Post Title Defined Handles Bot
+Missing killswitch for Bad Post Title Multi Bot
+Missing killswitch for Suspicious First Post
+Missing killswitch for Inconsistent Age Bot
+Missing killswitch for Inconsistent Gender Bot
+Missing killswitch for World Traveller
+Missing killswitch for Comment Phrase
+Missing killswitch for Telegram Group Bot
+Missing killswitch for Warmup Bot
+Missing killswitch for Social Links Bot
+Missing killswitch for Bot Group Advanced
+Missing killswitch for Title Copy Bot
+Missing killswitch for Bot Group Advanced Internal
+
+ [32m✓[39m src/userEvaluation/evaluatorVariables.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 84[2mms[22m[39m
+ [32m✓[39m src/statistics/submitterStatistics.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 17[2mms[22m[39m
+ [32m✓[39m src/dataStore.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 14[2mms[22m[39m
+ [32m✓[39m src/handleControlSubFlairUpdate.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 15[2mms[22m[39m
+ [32m✓[39m src/postCreation.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 13[2mms[22m[39m
+[90mstdout[2m | src/utility.test.ts[2m > [22m[2msendMessageToWebhook returns message id when webhook responds successfully
+[22m[39mWebhook message sent, status: [33m200[39m
+
+[90mstderr[2m | src/utility.test.ts[2m > [22m[2msendMessageToWebhook returns undefined when webhook responds with failure
+[22m[39mWebhook send failed with status 500: server error
+
+[90mstdout[2m | src/utility.test.ts[2m > [22m[2mupdateWebhookMessage returns true on success and false on failure
+[22m[39mWebhook message updated, status: [33m200[39m
+
+[90mstderr[2m | src/utility.test.ts[2m > [22m[2mupdateWebhookMessage returns true on success and false on failure
+[22m[39mWebhook update failed with status 404: not found
+
+ [32m✓[39m src/utility.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 29[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m8 passed[39m[22m[90m (8)[39m
+[2m      Tests [22m [1m[32m34 passed[39m[22m[90m (34)[39m
+[2m   Start at [22m 04:28:46
+[2m   Duration [22m 28.01s[2m (transform 3.79s, setup 0ms, import 158.05s, tests 200ms, environment 3ms)[22m
+

--- a/ts failed. Do not commit yet.
+++ b/ts failed. Do not commit yet.
@@ -1,0 +1,314 @@
+
+                   SSUUMMMMAARRYY OOFF LLEESSSS CCOOMMMMAANNDDSS
+
+      Commands marked with * may be preceded by a number, _N.
+      Notes in parentheses indicate the behavior if _N is given.
+      A key preceded by a caret indicates the Ctrl key; thus ^K is ctrl-K.
+
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+ ---------------------------------------------------------------------------
+
+                           MMOOVVIINNGG
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+  f  ^F  ^V  SPACE  *  Forward  one window (or _N lines).
+  b  ^B  ESC-v      *  Backward one window (or _N lines).
+  z                 *  Forward  one window (and set window to _N).
+  w                 *  Backward one window (and set window to _N).
+  ESC-SPACE         *  Forward  one window, but don't stop at end-of-file.
+  d  ^D             *  Forward  one half-window (and set half-window to _N).
+  u  ^U             *  Backward one half-window (and set half-window to _N).
+  ESC-)  RightArrow *  Right one half screen width (or _N positions).
+  ESC-(  LeftArrow  *  Left  one half screen width (or _N positions).
+  ESC-}  ^RightArrow   Right to last column displayed.
+  ESC-{  ^LeftArrow    Left  to first column.
+  F                    Forward forever; like "tail -f".
+  ESC-F                Like F but stop when search pattern is found.
+  r  ^R  ^L            Repaint screen.
+  R                    Repaint screen, discarding buffered input.
+        ---------------------------------------------------
+        Default "window" is the screen height.
+        Default "half-window" is half of the screen height.
+ ---------------------------------------------------------------------------
+
+                          SSEEAARRCCHHIINNGG
+
+  /_p_a_t_t_e_r_n          *  Search forward for (_N-th) matching line.
+  ?_p_a_t_t_e_r_n          *  Search backward for (_N-th) matching line.
+  n                 *  Repeat previous search (for _N-th occurrence).
+  N                 *  Repeat previous search in reverse direction.
+  ESC-n             *  Repeat previous search, spanning files.
+  ESC-N             *  Repeat previous search, reverse dir. & spanning files.
+  ^O^N  ^On         *  Search forward for (_N-th) OSC8 hyperlink.
+  ^O^P  ^Op         *  Search backward for (_N-th) OSC8 hyperlink.
+  ^O^L  ^Ol            Jump to the currently selected OSC8 hyperlink.
+  ESC-u                Undo (toggle) search highlighting.
+  ESC-U                Clear search highlighting.
+  &_p_a_t_t_e_r_n          *  Display only matching lines.
+        ---------------------------------------------------
+        A search pattern may begin with one or more of:
+        ^N or !  Search for NON-matching lines.
+        ^E or *  Search multiple files (pass thru END OF FILE).
+        ^F or @  Start search at FIRST file (for /) or last file (for ?).
+        ^K       Highlight matches, but don't move (KEEP position).
+        ^R       Don't use REGULAR EXPRESSIONS.
+        ^S _n     Search for match in _n-th parenthesized subpattern.
+        ^W       WRAP search if no match found.
+        ^L       Enter next character literally into pattern.
+ ---------------------------------------------------------------------------
+
+                           JJUUMMPPIINNGG
+
+  g  <  ESC-<       *  Go to first line in file (or line _N).
+  G  >  ESC->       *  Go to last line in file (or line _N).
+  p  %              *  Go to beginning of file (or _N percent into file).
+  t                 *  Go to the (_N-th) next tag.
+  T                 *  Go to the (_N-th) previous tag.
+  {  (  [           *  Find close bracket } ) ].
+  }  )  ]           *  Find open bracket { ( [.
+  ESC-^F _<_c_1_> _<_c_2_>  *  Find close bracket _<_c_2_>.
+  ESC-^B _<_c_1_> _<_c_2_>  *  Find open bracket _<_c_1_>.
+        ---------------------------------------------------
+        Each "find close bracket" command goes forward to the close bracket 
+          matching the (_N-th) open bracket in the top line.
+        Each "find open bracket" command goes backward to the open bracket 
+          matching the (_N-th) close bracket in the bottom line.
+
+  m_<_l_e_t_t_e_r_>            Mark the current top line with <letter>.
+  M_<_l_e_t_t_e_r_>            Mark the current bottom line with <letter>.
+  '_<_l_e_t_t_e_r_>            Go to a previously marked position.
+  ''                   Go to the previous position.
+  ^X^X                 Same as '.
+  ESC-m_<_l_e_t_t_e_r_>        Clear a mark.
+        ---------------------------------------------------
+        A mark is any upper-case or lower-case letter.
+        Certain marks are predefined:
+             ^  means  beginning of the file
+             $  means  end of the file
+ ---------------------------------------------------------------------------
+
+                        CCHHAANNGGIINNGG FFIILLEESS
+
+  :e [_f_i_l_e]            Examine a new file.
+  ^X^V                 Same as :e.
+  :n                *  Examine the (_N-th) next file from the command line.
+  :p                *  Examine the (_N-th) previous file from the command line.
+  :x                *  Examine the first (or _N-th) file from the command line.
+  ^O^O                 Open the currently selected OSC8 hyperlink.
+  :d                   Delete the current file from the command line list.
+  =  ^G  :f            Print current file name.
+ ---------------------------------------------------------------------------
+
+                    MMIISSCCEELLLLAANNEEOOUUSS CCOOMMMMAANNDDSS
+
+  -_<_f_l_a_g_>              Toggle a command line option [see OPTIONS below].
+  --_<_n_a_m_e_>             Toggle a command line option, by name.
+  __<_f_l_a_g_>              Display the setting of a command line option.
+  ___<_n_a_m_e_>             Display the setting of an option, by name.
+  +_c_m_d                 Execute the less cmd each time a new file is examined.
+
+  !_c_o_m_m_a_n_d             Execute the shell command with $SHELL.
+  #_c_o_m_m_a_n_d             Execute the shell command, expanded like a prompt.
+  |XX_c_o_m_m_a_n_d            Pipe file between current pos & mark XX to shell command.
+  s _f_i_l_e               Save input to a file.
+  v                    Edit the current file with $VISUAL or $EDITOR.
+  V                    Print version number of "less".
+ ---------------------------------------------------------------------------
+
+                           OOPPTTIIOONNSS
+
+        Most options may be changed either on the command line,
+        or from within less by using the - or -- command.
+        Options may be given in one of two forms: either a single
+        character preceded by a -, or a name preceded by --.
+
+  -?  ........  --help
+                  Display help (from command line).
+  -a  ........  --search-skip-screen
+                  Search skips current screen.
+  -A  ........  --SEARCH-SKIP-SCREEN
+                  Search starts just after target line.
+  -b [_N]  ....  --buffers=[_N]
+                  Number of buffers.
+  -B  ........  --auto-buffers
+                  Don't automatically allocate buffers for pipes.
+  -c  ........  --clear-screen
+                  Repaint by clearing rather than scrolling.
+  -d  ........  --dumb
+                  Dumb terminal.
+  -D xx_c_o_l_o_r  .  --color=xx_c_o_l_o_r
+                  Set screen colors.
+  -e  -E  ....  --quit-at-eof  --QUIT-AT-EOF
+                  Quit at end of file.
+  -f  ........  --force
+                  Force open non-regular files.
+  -F  ........  --quit-if-one-screen
+                  Quit if entire file fits on first screen.
+  -g  ........  --hilite-search
+                  Highlight only last match for searches.
+  -G  ........  --HILITE-SEARCH
+                  Don't highlight any matches for searches.
+  -h [_N]  ....  --max-back-scroll=[_N]
+                  Backward scroll limit.
+  -i  ........  --ignore-case
+                  Ignore case in searches that do not contain uppercase.
+  -I  ........  --IGNORE-CASE
+                  Ignore case in all searches.
+  -j [_N]  ....  --jump-target=[_N]
+                  Screen position of target lines.
+  -J  ........  --status-column
+                  Display a status column at left edge of screen.
+  -k _f_i_l_e  ...  --lesskey-file=_f_i_l_e
+                  Use a compiled lesskey file.
+  -K  ........  --quit-on-intr
+                  Exit less in response to ctrl-C.
+  -L  ........  --no-lessopen
+                  Ignore the LESSOPEN environment variable.
+  -m  -M  ....  --long-prompt  --LONG-PROMPT
+                  Set prompt style.
+  -n .........  --line-numbers
+                  Suppress line numbers in prompts and messages.
+  -N .........  --LINE-NUMBERS
+                  Display line number at start of each line.
+  -o [_f_i_l_e] ..  --log-file=[_f_i_l_e]
+                  Copy to log file (standard input only).
+  -O [_f_i_l_e] ..  --LOG-FILE=[_f_i_l_e]
+                  Copy to log file (unconditionally overwrite).
+  -p _p_a_t_t_e_r_n .  --pattern=[_p_a_t_t_e_r_n]
+                  Start at pattern (from command line).
+  -P [_p_r_o_m_p_t]   --prompt=[_p_r_o_m_p_t]
+                  Define new prompt.
+  -q  -Q  ....  --quiet  --QUIET  --silent --SILENT
+                  Quiet the terminal bell.
+  -r  -R  ....  --raw-control-chars  --RAW-CONTROL-CHARS
+                  Output "raw" control characters.
+  -s  ........  --squeeze-blank-lines
+                  Squeeze multiple blank lines.
+  -S  ........  --chop-long-lines
+                  Chop (truncate) long lines rather than wrapping.
+  -t _t_a_g  ....  --tag=[_t_a_g]
+                  Find a tag.
+  -T [_t_a_g_s_f_i_l_e] --tag-file=[_t_a_g_s_f_i_l_e]
+                  Use an alternate tags file.
+  -u  -U  ....  --underline-special  --UNDERLINE-SPECIAL
+                  Change handling of backspaces, tabs and carriage returns.
+  -V  ........  --version
+                  Display the version number of "less".
+  -w  ........  --hilite-unread
+                  Highlight first new line after forward-screen.
+  -W  ........  --HILITE-UNREAD
+                  Highlight first new line after any forward movement.
+  -x [_N[,...]]  --tabs=[_N[,...]]
+                  Set tab stops.
+  -X  ........  --no-init
+                  Don't use termcap init/deinit strings.
+  -y [_N]  ....  --max-forw-scroll=[_N]
+                  Forward scroll limit.
+  -z [_N]  ....  --window=[_N]
+                  Set size of window.
+  -" [_c[_c]]  .  --quotes=[_c[_c]]
+                  Set shell quote characters.
+  -~  ........  --tilde
+                  Don't display tildes after end of file.
+  -# [_N]  ....  --shift=[_N]
+                  Set horizontal scroll amount (0 = one half screen width).
+
+                --exit-follow-on-close
+                  Exit F command on a pipe when writer closes pipe.
+                --file-size
+                  Automatically determine the size of the input file.
+                --follow-name
+                  The F command changes files if the input file is renamed.
+                --header=[_L[,_C[,_N]]]
+                  Use _L lines (starting at line _N) and _C columns as headers.
+                --incsearch
+                  Search file as each pattern character is typed in.
+                --intr=[_C]
+                  Use _C instead of ^X to interrupt a read.
+                --lesskey-context=_t_e_x_t
+                  Use lesskey source file contents.
+                --lesskey-src=_f_i_l_e
+                  Use a lesskey source file.
+                --line-num-width=[_N]
+                  Set the width of the -N line number field to _N characters.
+                --match-shift=[_N]
+                  Show at least _N characters to the left of a search match.
+                --modelines=[_N]
+                  Read _N lines from the input file and look for vim modelines.
+                --mouse
+                  Enable mouse input.
+                --no-keypad
+                  Don't send termcap keypad init/deinit strings.
+                --no-histdups
+                  Remove duplicates from command history.
+                --no-number-headers
+                  Don't give line numbers to header lines.
+                --no-search-header-lines
+                  Searches do not include header lines.
+                --no-search-header-columns
+                  Searches do not include header columns.
+                --no-search-headers
+                  Searches do not include header lines or columns.
+                --no-vbell
+                  Disable the terminal's visual bell.
+                --redraw-on-quit
+                  Redraw final screen when quitting.
+                --rscroll=[_C]
+                  Set the character used to mark truncated lines.
+                --save-marks
+                  Retain marks across invocations of less.
+                --search-options=[EFKNRW-]
+                  Set default options for every search.
+                --show-preproc-errors
+                  Display a message if preprocessor exits with an error status.
+                --proc-backspace
+                  Process backspaces for bold/underline.
+                --PROC-BACKSPACE
+                  Treat backspaces as control characters.
+                --proc-return
+                  Delete carriage returns before newline.
+                --PROC-RETURN
+                  Treat carriage returns as control characters.
+                --proc-tab
+                  Expand tabs to spaces.
+                --PROC-TAB
+                  Treat tabs as control characters.
+                --status-col-width=[_N]
+                  Set the width of the -J status column to _N characters.
+                --status-line
+                  Highlight or color the entire line containing a mark.
+                --use-backslash
+                  Subsequent options use backslash as escape char.
+                --use-color
+                  Enables colored text.
+                --wheel-lines=[_N]
+                  Each click of the mouse wheel moves _N lines.
+                --wordwrap
+                  Wrap lines at spaces.
+
+
+ ---------------------------------------------------------------------------
+
+                          LLIINNEE EEDDIITTIINNGG
+
+        These keys can be used to edit text being entered 
+        on the "command line" at the bottom of the screen.
+
+ RightArrow ..................... ESC-l ... Move cursor right one character.
+ LeftArrow ...................... ESC-h ... Move cursor left one character.
+ ctrl-RightArrow  ESC-RightArrow  ESC-w ... Move cursor right one word.
+ ctrl-LeftArrow   ESC-LeftArrow   ESC-b ... Move cursor left one word.
+ HOME ........................... ESC-0 ... Move cursor to start of line.
+ END ............................ ESC-$ ... Move cursor to end of line.
+ BACKSPACE ................................ Delete char to left of cursor.
+ DELETE ......................... ESC-x ... Delete char under cursor.
+ ctrl-BACKSPACE   ESC-BACKSPACE ........... Delete word to left of cursor.
+ ctrl-DELETE .... ESC-DELETE .... ESC-X ... Delete word under cursor.
+ ctrl-U ......... ESC (MS-DOS only) ....... Delete entire line.
+ UpArrow ........................ ESC-k ... Retrieve previous command line.
+ DownArrow ...................... ESC-j ... Retrieve next command line.
+ TAB ...................................... Complete filename & cycle.
+ SHIFT-TAB ...................... ESC-TAB   Complete filename & reverse cycle.
+ ctrl-L ................................... Complete filename, list all.

--- a/tunit
+++ b/tunit
@@ -1,0 +1,58 @@
+warning: in the working copy of 'src/handleReportUser.ts', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'src/main.ts', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'src/modmail/evaluatorReversals.ts', LF will be replaced by CRLF the next time Git touches it
+[1mdiff --git a/src/handleReportUser.ts b/src/handleReportUser.ts[m
+[1mindex 90f1842..054db37 100644[m
+[1m--- a/src/handleReportUser.ts[m
+[1m+++ b/src/handleReportUser.ts[m
+[36m@@ -185,12 +185,8 @@[m [mexport async function handleReportUser (event: MenuItemOnPressEvent, context: Co[m
+ [m
+     const data = {[m
+         username: target.authorName,[m
+[31m-<<<<<<< Updated upstream[m
+         userFeedbackPreference: await getUserFeedbackPreference(currentUser.username, context),[m
+[31m-=======[m
+[31m-        configRevisionNotice,[m
+[31m->>>>>>> Stashed changes[m
+[31m-        feedbackHelpText: canReceiveFeedback ? "You must be able to receive chat messages from /u/bot-bouncer to receive this notification" : "We've tried to send feedback for you several times but this hasn't worked. Check to make sure you can receive chats from /u/bot-bouncer. This option will return within 24h.",[m
+[32m+[m[32m        configRevisionNotice,        feedbackHelpText: canReceiveFeedback ? "You must be able to receive chat messages from /u/bot-bouncer to receive this notification" : "We've tried to send feedback for you several times but this hasn't worked. Check to make sure you can receive chats from /u/bot-bouncer. This option will return within 24h.",[m
+         feedbackDisabled: !canReceiveFeedback,[m
+     };[m
+ [m
+[1mdiff --git a/src/main.ts b/src/main.ts[m
+[1mindex f673150..580e4e6 100644[m
+[1m--- a/src/main.ts[m
+[1m+++ b/src/main.ts[m
+[36m@@ -20,14 +20,8 @@[m [mimport { perform6HourlyJobs, perform6HourlyJobsPart2 } from "./scheduler/sixHour[m
+ import { checkUptimeAndMessages } from "./uptimeMonitor.js";[m
+ import { handleRapidJob } from "./scheduler/handleRapidJob.js";[m
+ import { buildEvaluatorAccuracyStatistics } from "./statistics/evaluatorAccuracyStatistics.js";[m
+[31m-<<<<<<< Updated upstream[m
+ import { definedHandlesStatsInitializer, gatherDefinedHandlesStats, storeDefinedHandlesDataJob } from "./statistics/definedHandlesStatistics.js";[m
+[31m-import { deleteRecordsForRemovedUsers, classificationReversalsJob, reversePostCreationQueue } from "./modmail/evaluatorReversals.js";[m
+[31m-=======[m
+[31m-import { gatherDefinedHandlesStats, storeDefinedHandlesDataJob } from "./statistics/definedHandlesStatistics.js";[m
+[31m-import { deleteRecordsForRemovedUsers, classificationReversalsJob, reversePostCreationQueue, emergencyConfigCleanupJob } from "./modmail/evaluatorReversals.js";[m
+[31m->>>>>>> Stashed changes[m
+[31m-import { handleCommentCreate, handlePostCreate, handlePostSubmit } from "./handleContentCreation.js";[m
+[32m+[m[32mimport { deleteRecordsForRemovedUsers, classificationReversalsJob, reversePostCreationQueue, emergencyConfigCleanupJob } from "./modmail/evaluatorReversals.js";import { handleCommentCreate, handlePostCreate, handlePostSubmit } from "./handleContentCreation.js";[m
+ import { conditionalStatsUpdate } from "./statistics/conditionalStatsUpdate.js";[m
+ import { asyncWikiUpdate } from "./statistics/asyncWikiUpdate.js";[m
+ import { generateBioStatisticsReport, updateBioStatisticsJob } from "./statistics/userBioStatistics.js";[m
+[1mdiff --git a/src/modmail/evaluatorReversals.ts b/src/modmail/evaluatorReversals.ts[m
+[1mindex 2273198..ab8aa97 100644[m
+[1m--- a/src/modmail/evaluatorReversals.ts[m
+[1m+++ b/src/modmail/evaluatorReversals.ts[m
+[36m@@ -9,11 +9,8 @@[m [mimport Ajv, { JSONSchemaType } from "ajv";[m
+ import { AsyncSubmission } from "../postCreation.js";[m
+ import pluralize from "pluralize";[m
+ import json2md from "json2md";[m
+[31m-<<<<<<< Updated upstream[m
+[31m-=======[m
+[32m+[m[32mimport json2md from "json2md";[m
+ import { getConfigRevisionReceipt } from "../configRevisionReceipts.js";[m
+[31m->>>>>>> Stashed changes[m
+[31m-[m
+ const REVERSED_USERS = "ReversedUsers";[m
+ [m
+ export async function addToReversalsQueue (username: string, days: number, context: TriggerContext) {[m


### PR DESCRIPTION
Closes #455

This patch focuses on catching previously unclassified users who edit posts/comments to include content that matches evaluator config.