### PR TITLE
Add Discord alert for stalled Bot Bouncer posts

### DIFF
--- a/src/postCreation.ts
+++ b/src/postCreation.ts
@@ -8,6 +8,7 @@ import pluralize from "pluralize";
 import { queueSendFeedback } from "./submissionFeedback.js";
 import { formatTimeSince, isBannedWithCache, sendMessageToWebhook, updateWebhookMessage } from "./utility.js";
 import { isUserSubmitterOrMod } from "./cleanup.js";
+import { recordBotPostCreated } from "./scheduler/botPostMonitor.js";
 
 export const statusToFlair: Record<UserStatus, PostFlairTemplate> = {
     [UserStatus.Pending]: PostFlairTemplate.Pending,
@@ -105,6 +106,12 @@ async function createNewSubmission (submission: AsyncSubmission, context: Trigge
         flairId: statusToFlair[submission.details.userStatus],
         nsfw: submission.user.nsfw,
     });
+
+    try {
+        await recordBotPostCreated(newPost, context);
+    } catch (error) {
+        console.error("Bot Post Monitor: Error recording new bot post.", error);
+    }
 
     submission.details.trackingPostId = newPost.id;
     submission.details.reportedAt = Date.now();

--- a/src/scheduler/botPostMonitor.test.ts
+++ b/src/scheduler/botPostMonitor.test.ts
@@ -1,52 +1,62 @@
-import { BOT_POST_MONITOR_THRESHOLD_MINUTES, getBotPostFreshness } from "./botPostMonitor.js";
-import { CONTROL_SUBREDDIT } from "../constants.js";
+import { BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES, BotPostRecord, getBotPostFreshness, getBotPostMonitorThresholdMinutes } from "./botPostMonitor.js";
 
-function post (createdAt: Date, overrides = {}) {
+function postRecord (createdAt: Date, overrides = {}): BotPostRecord {
     return {
-        authorName: "bot-bouncer",
         createdAt,
         id: "t3_test",
-        subredditName: CONTROL_SUBREDDIT,
         ...overrides,
     };
 }
 
-test("bot post freshness is fresh when latest control sub post is newer than threshold", () => {
+test("bot post freshness is fresh when latest post is newer than default threshold", () => {
     const now = new Date("2026-06-23T15:00:00Z");
-    const result = getBotPostFreshness([
-        post(new Date("2026-06-23T14:56:00Z")),
-    ], "bot-bouncer", now);
+    const result = getBotPostFreshness(
+        postRecord(new Date("2026-06-23T14:41:00Z")),
+        BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES,
+        now,
+    );
 
     expect(result.stale).toBe(false);
-    expect(result.minutesSinceLatestPost).toBe(BOT_POST_MONITOR_THRESHOLD_MINUTES - 1);
+    expect(result.minutesSinceLatestPost).toBe(BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES - 1);
 });
 
-test("bot post freshness is stale when latest control sub post is at threshold", () => {
+test("bot post freshness is stale when latest post is at default threshold", () => {
     const now = new Date("2026-06-23T15:00:00Z");
-    const result = getBotPostFreshness([
-        post(new Date("2026-06-23T14:55:00Z")),
-    ], "bot-bouncer", now);
+    const result = getBotPostFreshness(
+        postRecord(new Date("2026-06-23T14:40:00Z")),
+        BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES,
+        now,
+    );
 
     expect(result.stale).toBe(true);
-    expect(result.minutesSinceLatestPost).toBe(BOT_POST_MONITOR_THRESHOLD_MINUTES);
+    expect(result.minutesSinceLatestPost).toBe(BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES);
 });
 
-test("bot post freshness ignores posts outside the control subreddit", () => {
+test("bot post freshness uses configured threshold", () => {
     const now = new Date("2026-06-23T15:00:00Z");
-    const result = getBotPostFreshness([
-        post(new Date("2026-06-23T14:59:00Z"), { subredditName: "SomeClientSub" }),
-        post(new Date("2026-06-23T14:50:00Z")),
-    ], "bot-bouncer", now);
+    const result = getBotPostFreshness(
+        postRecord(new Date("2026-06-23T14:44:00Z")),
+        15,
+        now,
+    );
 
     expect(result.stale).toBe(true);
-    expect(result.minutesSinceLatestPost).toBe(10);
+    expect(result.minutesSinceLatestPost).toBe(16);
 });
 
-test("bot post freshness is stale when no bot post is found", () => {
-    const result = getBotPostFreshness([
-        post(new Date("2026-06-23T14:59:00Z"), { authorName: "other-user" }),
-    ], "bot-bouncer", new Date("2026-06-23T15:00:00Z"));
+test("bot post freshness does not alert before a post creation record exists", () => {
+    const result = getBotPostFreshness(undefined, BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES, new Date("2026-06-23T15:00:00Z"));
 
-    expect(result.stale).toBe(true);
+    expect(result.stale).toBe(false);
     expect(result.latestPost).toBeUndefined();
+});
+
+test("bot post monitor threshold defaults to twenty minutes", () => {
+    expect(getBotPostMonitorThresholdMinutes({})).toBe(20);
+    expect(getBotPostMonitorThresholdMinutes({ botPostMonitorThresholdMinutes: 0 })).toBe(20);
+});
+
+test("bot post monitor threshold uses positive configured values", () => {
+    expect(getBotPostMonitorThresholdMinutes({ botPostMonitorThresholdMinutes: 15 })).toBe(15);
+    expect(getBotPostMonitorThresholdMinutes({ botPostMonitorThresholdMinutes: 20 })).toBe(20);
 });

--- a/src/scheduler/botPostMonitor.test.ts
+++ b/src/scheduler/botPostMonitor.test.ts
@@ -1,0 +1,52 @@
+import { BOT_POST_MONITOR_THRESHOLD_MINUTES, getBotPostFreshness } from "./botPostMonitor.js";
+import { CONTROL_SUBREDDIT } from "../constants.js";
+
+function post (createdAt: Date, overrides = {}) {
+    return {
+        authorName: "bot-bouncer",
+        createdAt,
+        id: "t3_test",
+        subredditName: CONTROL_SUBREDDIT,
+        ...overrides,
+    };
+}
+
+test("bot post freshness is fresh when latest control sub post is newer than threshold", () => {
+    const now = new Date("2026-06-23T15:00:00Z");
+    const result = getBotPostFreshness([
+        post(new Date("2026-06-23T14:56:00Z")),
+    ], "bot-bouncer", now);
+
+    expect(result.stale).toBe(false);
+    expect(result.minutesSinceLatestPost).toBe(BOT_POST_MONITOR_THRESHOLD_MINUTES - 1);
+});
+
+test("bot post freshness is stale when latest control sub post is at threshold", () => {
+    const now = new Date("2026-06-23T15:00:00Z");
+    const result = getBotPostFreshness([
+        post(new Date("2026-06-23T14:55:00Z")),
+    ], "bot-bouncer", now);
+
+    expect(result.stale).toBe(true);
+    expect(result.minutesSinceLatestPost).toBe(BOT_POST_MONITOR_THRESHOLD_MINUTES);
+});
+
+test("bot post freshness ignores posts outside the control subreddit", () => {
+    const now = new Date("2026-06-23T15:00:00Z");
+    const result = getBotPostFreshness([
+        post(new Date("2026-06-23T14:59:00Z"), { subredditName: "SomeClientSub" }),
+        post(new Date("2026-06-23T14:50:00Z")),
+    ], "bot-bouncer", now);
+
+    expect(result.stale).toBe(true);
+    expect(result.minutesSinceLatestPost).toBe(10);
+});
+
+test("bot post freshness is stale when no bot post is found", () => {
+    const result = getBotPostFreshness([
+        post(new Date("2026-06-23T14:59:00Z"), { authorName: "other-user" }),
+    ], "bot-bouncer", new Date("2026-06-23T15:00:00Z"));
+
+    expect(result.stale).toBe(true);
+    expect(result.latestPost).toBeUndefined();
+});

--- a/src/scheduler/botPostMonitor.ts
+++ b/src/scheduler/botPostMonitor.ts
@@ -1,49 +1,108 @@
 import { JobContext, Post } from "@devvit/public-api";
 import { differenceInMinutes } from "date-fns";
 import { CONTROL_SUBREDDIT } from "../constants.js";
-import { ControlSubSettings } from "../settings.js";
+import { ControlSubSettings, getControlSubSettings } from "../settings.js";
 import { postIdToShortLink, sendMessageToWebhook } from "../utility.js";
 
 const BOT_POST_MONITOR_ALERT_KEY = "botPostMonitorAlertSent";
-const BOT_POST_MONITOR_LOOKBACK_LIMIT = 25;
-export const BOT_POST_MONITOR_THRESHOLD_MINUTES = 5;
+const BOT_POST_MONITOR_LAST_POST_KEY = "botPostMonitorLastPost";
+export const BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES = 20;
 
-type MonitorablePost = Pick<Post, "authorName" | "createdAt" | "id" | "subredditName">;
+type CreatedPost = Pick<Post, "createdAt" | "id">;
+
+export interface BotPostRecord {
+    createdAt: Date;
+    id?: string;
+}
 
 export interface BotPostFreshnessResult {
-    latestPost?: MonitorablePost;
+    latestPost?: BotPostRecord;
     minutesSinceLatestPost?: number;
     stale: boolean;
 }
 
-export function getBotPostFreshness (posts: MonitorablePost[], botUsername: string, now = new Date()): BotPostFreshnessResult {
-    const latestPost = posts
-        .filter(post => post.authorName.toLowerCase() === botUsername.toLowerCase() && post.subredditName.toLowerCase() === CONTROL_SUBREDDIT.toLowerCase())
-        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0];
+export function getBotPostMonitorThresholdMinutes (settings: Pick<ControlSubSettings, "botPostMonitorThresholdMinutes">): number {
+    const configuredThreshold = settings.botPostMonitorThresholdMinutes;
+    if (configuredThreshold === undefined || configuredThreshold < 1) {
+        return BOT_POST_MONITOR_DEFAULT_THRESHOLD_MINUTES;
+    }
 
+    return Math.floor(configuredThreshold);
+}
+
+export function getBotPostFreshness (latestPost: BotPostRecord | undefined, thresholdMinutes: number, now = new Date()): BotPostFreshnessResult {
     if (!latestPost) {
-        return { stale: true };
+        return { stale: false };
     }
 
     const minutesSinceLatestPost = differenceInMinutes(now, latestPost.createdAt);
     return {
         latestPost,
         minutesSinceLatestPost,
-        stale: minutesSinceLatestPost >= BOT_POST_MONITOR_THRESHOLD_MINUTES,
+        stale: minutesSinceLatestPost >= thresholdMinutes,
     };
 }
 
-function botPostAlertMessage (botUsername: string, freshness: BotPostFreshnessResult): string {
+function serializeBotPostRecord (record: BotPostRecord): string {
+    return JSON.stringify({
+        createdAt: record.createdAt.toISOString(),
+        id: record.id,
+    });
+}
+
+function parseBotPostRecord (record: string): BotPostRecord | undefined {
+    try {
+        const parsed = JSON.parse(record) as { createdAt?: string, id?: string };
+        if (!parsed.createdAt) {
+            return undefined;
+        }
+
+        const createdAt = new Date(parsed.createdAt);
+        if (Number.isNaN(createdAt.getTime())) {
+            return undefined;
+        }
+
+        return {
+            createdAt,
+            id: parsed.id,
+        };
+    } catch (error) {
+        console.error("Bot Post Monitor: Error parsing recorded bot post details.", error);
+        return undefined;
+    }
+}
+
+async function getLatestBotPostRecord (context: JobContext): Promise<BotPostRecord | undefined> {
+    const record = await context.redis.get(BOT_POST_MONITOR_LAST_POST_KEY);
+    return record ? parseBotPostRecord(record) : undefined;
+}
+
+async function initializeBotPostMonitorRecord (context: JobContext) {
+    await context.redis.set(BOT_POST_MONITOR_LAST_POST_KEY, serializeBotPostRecord({ createdAt: new Date() }));
+}
+
+export async function recordBotPostCreated (post: CreatedPost, context: Pick<JobContext, "redis">) {
+    await context.redis.set(BOT_POST_MONITOR_LAST_POST_KEY, serializeBotPostRecord({
+        createdAt: post.createdAt,
+        id: post.id,
+    }));
+}
+
+function botPostAlertMessage (botUsername: string, freshness: BotPostFreshnessResult, thresholdMinutes: number): string {
     if (!freshness.latestPost || freshness.minutesSinceLatestPost === undefined) {
-        return `🚨 No recent r/${CONTROL_SUBREDDIT} posts by u/${botUsername} were found in the newest ${BOT_POST_MONITOR_LOOKBACK_LIMIT} posts from the account. Post creation may be stalled.`;
+        return `🚨 No r/${CONTROL_SUBREDDIT} post creation record is available for u/${botUsername}. Post creation may be stalled.`;
+    }
+
+    if (!freshness.latestPost.id) {
+        return `🚨 No r/${CONTROL_SUBREDDIT} post by u/${botUsername} has been recorded for ${freshness.minutesSinceLatestPost.toLocaleString()} minutes since the monitor started. Alert threshold: ${thresholdMinutes.toLocaleString()} minutes.`;
     }
 
     const postCreatedAtUnix = Math.floor(freshness.latestPost.createdAt.getTime() / 1000);
-    return `🚨 u/${botUsername} has not created a new r/${CONTROL_SUBREDDIT} post in ${freshness.minutesSinceLatestPost.toLocaleString()} minutes. Latest detected post: <${postIdToShortLink(freshness.latestPost.id)}> created <t:${postCreatedAtUnix}:R>.`;
+    return `🚨 u/${botUsername} has not created a new r/${CONTROL_SUBREDDIT} post in ${freshness.minutesSinceLatestPost.toLocaleString()} minutes. Alert threshold: ${thresholdMinutes.toLocaleString()} minutes. Latest recorded post: <${postIdToShortLink(freshness.latestPost.id)}> created <t:${postCreatedAtUnix}:R>.`;
 }
 
 function botPostRecoveryMessage (botUsername: string, freshness: BotPostFreshnessResult): string {
-    if (!freshness.latestPost) {
+    if (!freshness.latestPost?.id) {
         return `✅ u/${botUsername} has resumed creating r/${CONTROL_SUBREDDIT} posts.`;
     }
 
@@ -51,9 +110,15 @@ function botPostRecoveryMessage (botUsername: string, freshness: BotPostFreshnes
     return `✅ u/${botUsername} created a new r/${CONTROL_SUBREDDIT} post at <t:${postCreatedAtUnix}:T>: <${postIdToShortLink(freshness.latestPost.id)}>.`;
 }
 
-export async function checkBotPostFreshness (settings: ControlSubSettings, context: JobContext) {
+export async function checkBotPostFreshness (context: JobContext) {
+    const settings = await getControlSubSettings(context);
     if (!settings.botPostMonitoringEnabled) {
         console.log("Bot Post Monitor: Monitor is disabled.");
+        return;
+    }
+
+    if (!settings.postCreationQueueProcessingEnabled) {
+        console.log("Bot Post Monitor: Post creation queue processing is disabled.");
         return;
     }
 
@@ -63,20 +128,16 @@ export async function checkBotPostFreshness (settings: ControlSubSettings, conte
         return;
     }
 
-    const botUsername = context.appSlug;
-    let posts: Post[];
-    try {
-        posts = await context.reddit.getPostsByUser({
-            username: botUsername,
-            sort: "new",
-            limit: BOT_POST_MONITOR_LOOKBACK_LIMIT,
-        }).all();
-    } catch (error) {
-        console.error("Bot Post Monitor: Error fetching recent bot posts.", error);
-        return;
+    let latestPost = await getLatestBotPostRecord(context);
+    if (!latestPost) {
+        console.log("Bot Post Monitor: No post creation record found. Initializing monitor timestamp.");
+        await initializeBotPostMonitorRecord(context);
+        latestPost = await getLatestBotPostRecord(context);
     }
 
-    const freshness = getBotPostFreshness(posts, botUsername);
+    const botUsername = context.appSlug;
+    const thresholdMinutes = getBotPostMonitorThresholdMinutes(settings);
+    const freshness = getBotPostFreshness(latestPost, thresholdMinutes);
     const existingAlertSentAt = await context.redis.get(BOT_POST_MONITOR_ALERT_KEY);
 
     if (!freshness.stale) {
@@ -92,7 +153,7 @@ export async function checkBotPostFreshness (settings: ControlSubSettings, conte
         return;
     }
 
-    const messageId = await sendMessageToWebhook(webhookUrl, botPostAlertMessage(botUsername, freshness));
+    const messageId = await sendMessageToWebhook(webhookUrl, botPostAlertMessage(botUsername, freshness, thresholdMinutes));
     if (messageId) {
         await context.redis.set(BOT_POST_MONITOR_ALERT_KEY, Date.now().toString());
     }

--- a/src/scheduler/botPostMonitor.ts
+++ b/src/scheduler/botPostMonitor.ts
@@ -1,0 +1,99 @@
+import { JobContext, Post } from "@devvit/public-api";
+import { differenceInMinutes } from "date-fns";
+import { CONTROL_SUBREDDIT } from "../constants.js";
+import { ControlSubSettings } from "../settings.js";
+import { postIdToShortLink, sendMessageToWebhook } from "../utility.js";
+
+const BOT_POST_MONITOR_ALERT_KEY = "botPostMonitorAlertSent";
+const BOT_POST_MONITOR_LOOKBACK_LIMIT = 25;
+export const BOT_POST_MONITOR_THRESHOLD_MINUTES = 5;
+
+type MonitorablePost = Pick<Post, "authorName" | "createdAt" | "id" | "subredditName">;
+
+export interface BotPostFreshnessResult {
+    latestPost?: MonitorablePost;
+    minutesSinceLatestPost?: number;
+    stale: boolean;
+}
+
+export function getBotPostFreshness (posts: MonitorablePost[], botUsername: string, now = new Date()): BotPostFreshnessResult {
+    const latestPost = posts
+        .filter(post => post.authorName.toLowerCase() === botUsername.toLowerCase() && post.subredditName.toLowerCase() === CONTROL_SUBREDDIT.toLowerCase())
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0];
+
+    if (!latestPost) {
+        return { stale: true };
+    }
+
+    const minutesSinceLatestPost = differenceInMinutes(now, latestPost.createdAt);
+    return {
+        latestPost,
+        minutesSinceLatestPost,
+        stale: minutesSinceLatestPost >= BOT_POST_MONITOR_THRESHOLD_MINUTES,
+    };
+}
+
+function botPostAlertMessage (botUsername: string, freshness: BotPostFreshnessResult): string {
+    if (!freshness.latestPost || freshness.minutesSinceLatestPost === undefined) {
+        return `🚨 No recent r/${CONTROL_SUBREDDIT} posts by u/${botUsername} were found in the newest ${BOT_POST_MONITOR_LOOKBACK_LIMIT} posts from the account. Post creation may be stalled.`;
+    }
+
+    const postCreatedAtUnix = Math.floor(freshness.latestPost.createdAt.getTime() / 1000);
+    return `🚨 u/${botUsername} has not created a new r/${CONTROL_SUBREDDIT} post in ${freshness.minutesSinceLatestPost.toLocaleString()} minutes. Latest detected post: <${postIdToShortLink(freshness.latestPost.id)}> created <t:${postCreatedAtUnix}:R>.`;
+}
+
+function botPostRecoveryMessage (botUsername: string, freshness: BotPostFreshnessResult): string {
+    if (!freshness.latestPost) {
+        return `✅ u/${botUsername} has resumed creating r/${CONTROL_SUBREDDIT} posts.`;
+    }
+
+    const postCreatedAtUnix = Math.floor(freshness.latestPost.createdAt.getTime() / 1000);
+    return `✅ u/${botUsername} created a new r/${CONTROL_SUBREDDIT} post at <t:${postCreatedAtUnix}:T>: <${postIdToShortLink(freshness.latestPost.id)}>.`;
+}
+
+export async function checkBotPostFreshness (settings: ControlSubSettings, context: JobContext) {
+    if (!settings.botPostMonitoringEnabled) {
+        console.log("Bot Post Monitor: Monitor is disabled.");
+        return;
+    }
+
+    const webhookUrl = settings.botNotificationsWebhook;
+    if (!webhookUrl) {
+        console.log("Bot Post Monitor: No bot notifications webhook configured.");
+        return;
+    }
+
+    const botUsername = context.appSlug;
+    let posts: Post[];
+    try {
+        posts = await context.reddit.getPostsByUser({
+            username: botUsername,
+            sort: "new",
+            limit: BOT_POST_MONITOR_LOOKBACK_LIMIT,
+        }).all();
+    } catch (error) {
+        console.error("Bot Post Monitor: Error fetching recent bot posts.", error);
+        return;
+    }
+
+    const freshness = getBotPostFreshness(posts, botUsername);
+    const existingAlertSentAt = await context.redis.get(BOT_POST_MONITOR_ALERT_KEY);
+
+    if (!freshness.stale) {
+        if (existingAlertSentAt) {
+            await sendMessageToWebhook(webhookUrl, botPostRecoveryMessage(botUsername, freshness));
+            await context.redis.del(BOT_POST_MONITOR_ALERT_KEY);
+        }
+        return;
+    }
+
+    if (existingAlertSentAt) {
+        console.log("Bot Post Monitor: Stale bot post alert already sent.");
+        return;
+    }
+
+    const messageId = await sendMessageToWebhook(webhookUrl, botPostAlertMessage(botUsername, freshness));
+    if (messageId) {
+        await context.redis.set(BOT_POST_MONITOR_ALERT_KEY, Date.now().toString());
+    }
+}

--- a/src/scheduler/handleMinutelyJob.ts
+++ b/src/scheduler/handleMinutelyJob.ts
@@ -3,6 +3,8 @@ import { processFeedbackQueue } from "../submissionFeedback.js";
 import { handleClassificationQueryQueue } from "../modmail/classificationQuery.js";
 import { areAnyDelayedMessagesQueued } from "../modmail/delayedSend.js";
 import { CONTROL_SUBREDDIT, ControlSubredditJob } from "../constants.js";
+import { getControlSubSettings } from "../settings.js";
+import { checkBotPostFreshness } from "./botPostMonitor.js";
 
 export async function handleMinutelyJob (_: unknown, context: JobContext) {
     if (context.subredditName !== CONTROL_SUBREDDIT) {
@@ -20,5 +22,6 @@ export async function handleMinutelyJob (_: unknown, context: JobContext) {
     await Promise.allSettled([
         processFeedbackQueue(context),
         handleClassificationQueryQueue(context),
+        getControlSubSettings(context).then(settings => checkBotPostFreshness(settings, context)),
     ]);
 }

--- a/src/scheduler/handleMinutelyJob.ts
+++ b/src/scheduler/handleMinutelyJob.ts
@@ -3,7 +3,6 @@ import { processFeedbackQueue } from "../submissionFeedback.js";
 import { handleClassificationQueryQueue } from "../modmail/classificationQuery.js";
 import { areAnyDelayedMessagesQueued } from "../modmail/delayedSend.js";
 import { CONTROL_SUBREDDIT, ControlSubredditJob } from "../constants.js";
-import { getControlSubSettings } from "../settings.js";
 import { checkBotPostFreshness } from "./botPostMonitor.js";
 
 export async function handleMinutelyJob (_: unknown, context: JobContext) {
@@ -22,6 +21,6 @@ export async function handleMinutelyJob (_: unknown, context: JobContext) {
     await Promise.allSettled([
         processFeedbackQueue(context),
         handleClassificationQueryQueue(context),
-        getControlSubSettings(context).then(settings => checkBotPostFreshness(settings, context)),
+        checkBotPostFreshness(context),
     ]);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -279,7 +279,9 @@ export interface ControlSubSettings {
     cleanupDisabled?: boolean;
     uptimeMonitoringEnabled?: boolean;
     messageMonitoringEnabled?: boolean;
+    botPostMonitoringEnabled?: boolean;
     monitoringWebhook?: string;
+    botNotificationsWebhook?: string;
     backlogWebhook?: string;
     banNoteCheckingEnabled?: boolean;
     observerSubreddits?: string[];
@@ -318,7 +320,9 @@ const schema: JSONSchemaType<ControlSubSettings> = {
         cleanupDisabled: { type: "boolean", nullable: true },
         uptimeMonitoringEnabled: { type: "boolean", nullable: true },
         messageMonitoringEnabled: { type: "boolean", nullable: true },
+        botPostMonitoringEnabled: { type: "boolean", nullable: true },
         monitoringWebhook: { type: "string", nullable: true },
+        botNotificationsWebhook: { type: "string", nullable: true },
         backlogWebhook: { type: "string", nullable: true },
         banNoteCheckingEnabled: { type: "boolean", nullable: true },
         observerSubreddits: { type: "array", items: { type: "string" }, nullable: true },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -280,6 +280,7 @@ export interface ControlSubSettings {
     uptimeMonitoringEnabled?: boolean;
     messageMonitoringEnabled?: boolean;
     botPostMonitoringEnabled?: boolean;
+    botPostMonitorThresholdMinutes?: number;
     monitoringWebhook?: string;
     botNotificationsWebhook?: string;
     backlogWebhook?: string;
@@ -321,6 +322,7 @@ const schema: JSONSchemaType<ControlSubSettings> = {
         uptimeMonitoringEnabled: { type: "boolean", nullable: true },
         messageMonitoringEnabled: { type: "boolean", nullable: true },
         botPostMonitoringEnabled: { type: "boolean", nullable: true },
+        botPostMonitorThresholdMinutes: { type: "number", nullable: true },
         monitoringWebhook: { type: "string", nullable: true },
         botNotificationsWebhook: { type: "string", nullable: true },
         backlogWebhook: { type: "string", nullable: true },


### PR DESCRIPTION
This alert will send a notification to the team's Discord server when u/bot-bouncer does not publish a new post after 5 minutes. Another alert will be sent when the posts resume.