### PR TITLE
Add option to remove reported content

### DIFF
--- a/src/handleReportUser.ts
+++ b/src/handleReportUser.ts
@@ -5,7 +5,7 @@ import { getUserStatus, UserStatus } from "./dataStore.js";
 import { addExternalSubmissionFromClientSub } from "./externalSubmissions.js";
 import { queryForm, reportForm } from "./main.js";
 import { addDays, addMinutes, subMonths } from "date-fns";
-import { getControlSubSettings } from "./settings.js";
+import { AppSetting, getControlSubSettings } from "./settings.js";
 import { handleControlSubReportUser } from "./handleControlSubMenu.js";
 import { recordReportForSummary } from "./modmail/actionSummary.js";
 import { canUserReceiveFeedback } from "./submissionFeedback.js";
@@ -198,6 +198,7 @@ export async function reportFormHandler (event: FormOnSubmitEvent<JSONObject>, c
     }
 
     const currentUser = await context.reddit.getCurrentUser();
+    const removeReportedContent = await context.settings.get<boolean>(AppSetting.RemoveReportedContentOnReport);
     const reportContext = event.values[ReportFormField.ReportContext] as string | undefined;
 
     await Promise.all([
@@ -214,9 +215,30 @@ export async function reportFormHandler (event: FormOnSubmitEvent<JSONObject>, c
         recordReportForSummary(target.authorName, context.redis),
     ]);
 
+    let reportedContentRemoved = false;
+    let reportedContentRemoveFailed = false;
+
+    if (removeReportedContent && !target.removed && !target.spam) {
+        try {
+            await target.remove();
+            reportedContentRemoved = true;
+        } catch (error) {
+            reportedContentRemoveFailed = true;
+            console.error(`Failed to remove reported content ${target.id} for ${target.authorName}:`, error);
+        }
+    }
+
     await setAlreadyReported(target.authorName, context);
 
-    context.ui.showToast(`${target.authorName} has been submitted to /r/${CONTROL_SUBREDDIT}. A tracking post will be created shortly.`);
+    let toastMessage = `${target.authorName} has been submitted to /r/${CONTROL_SUBREDDIT}. A tracking post will be created shortly.`;
+
+    if (reportedContentRemoved) {
+        toastMessage += " The reported content was removed.";
+    } else if (reportedContentRemoveFailed) {
+        toastMessage += " The reported content could not be removed.";
+    }
+
+    context.ui.showToast(toastMessage);
 
     if (currentUser?.username) {
         await setUserFeedbackPreference(currentUser.username, event.values[ReportFormField.SendFeedback] as boolean | undefined ?? false, context);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -49,6 +49,7 @@ export enum AppSetting {
     Action = "action",
     LockContentWhenRemoving = "lockContentWhenRemoving",
     RemoveFromModqueueWhenBanning = "removeFromModqueueWhenBanning",
+    RemoveReportedContentOnReport = "removeReportedContentOnReport",
     BanMessage = "banMessage",
     AutoWhitelist = "autoWhitelist",
     ExemptApprovedUsers = "exemptApprovedUsers",
@@ -110,6 +111,13 @@ export const appSettings: SettingsFormField[] = [
                 label: "Remove content from modqueue when banning",
                 helpText: "If banning users, also remove user content from the modqueue",
                 defaultValue: true,
+            },
+            {
+                type: "boolean",
+                name: AppSetting.RemoveReportedContentOnReport,
+                label: "Remove content when reporting users to Bot Bouncer",
+                helpText: "If enabled, using the post/comment context menu to report a user to Bot Bouncer will also remove the reported post or comment from this subreddit.",
+                defaultValue: false,
             },
             {
                 type: "boolean",


### PR DESCRIPTION
Closes #410.

This adds an opt-in subreddit setting to remove the specific post or comment used when reporting a suspected bot to Bot Bouncer. The report still submits even if content removal fails, and the setting defaults to off to avoid surprising moderators.

Testing completed:

* `npm.cmd exec -- eslint .`
* `npm.cmd test`
