### PR TITLE
Warn appellants when Bot Bouncer lacks subreddit permissions

### DIFF
--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -127,6 +127,10 @@ interface AppealOutcome {
     highlight?: boolean;
 }
 
+interface HandleAppealOptions {
+    suppressDefaultReply?: boolean;
+}
+
 const defaultAppealOutcome: AppealOutcome = {
     name: "Default Appeal Reply",
     reply: `Your classification appeal has been received and will be reviewed by a moderator. If accepted, the result of your appeal will apply to any subreddit using /r/${CONTROL_SUBREDDIT}.
@@ -326,7 +330,7 @@ function isAppealGrantStatus (status: string | undefined): boolean {
         || status === UserFlag.FutureNSFW;
 }
 
-export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDetails, context: TriggerContext): Promise<AppealOutcomeType> {
+export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDetails, context: TriggerContext, options?: HandleAppealOptions): Promise<AppealOutcomeType> {
     const username = modmail.participant;
     if (!username) {
         return AppealOutcomeType.Skipped;
@@ -567,7 +571,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
         };
     } else {
         console.log(`Appeals: No specific appeal config matched for user ${username}, using default reply.`);
-        appealOutcome = defaultAppealOutcome;
+        appealOutcome = options?.suppressDefaultReply === true ? { name: defaultAppealOutcome.name } : defaultAppealOutcome;
     }
 
     if (appealOutcome.newStatus && userDetails.trackingPostId) {

--- a/src/modmail/controlSubModmail.ts
+++ b/src/modmail/controlSubModmail.ts
@@ -18,7 +18,7 @@ import { FLAIR_MAPPINGS } from "../handleControlSubFlairUpdate.js";
 import _ from "lodash";
 import { CHECK_DATE_KEY } from "../karmaFarmingSubsCheck.js";
 import { evaluateAccountFromModmail } from "./modmailEvaluaton.js";
-import { isBanned } from "devvit-helpers";
+import { hasPermissions, isBanned } from "devvit-helpers";
 import { handleReversalCommand } from "./evaluatorReversals.js";
 import { handleHighlightedModmail } from "./unhighlighter.js";
 import { getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
@@ -28,6 +28,8 @@ import { handleAskAI } from "../aiAnalysis/askAI.js";
 export function getPossibleSetStatusValues (): string[] {
     return _.uniq([...FLAIR_MAPPINGS.map(entry => entry.postFlair), ...Object.values(UserStatus)]);
 }
+
+const REQUIRED_BOT_PERMISSIONS = ["access", "posts", "mail"];
 
 export async function handleControlSubredditModmail (modmail: ModmailMessage, context: TriggerContext) {
     const controlSubSettings = await getControlSubSettings(context);
@@ -295,7 +297,19 @@ async function handleModmailFromUser (modmail: ModmailMessage, context: TriggerC
         return;
     }
 
-    const appealOutcomeType = await handleAppeal(modmail, currentStatus, context);
+    const appealPermissionsIssueSubredditName = await getAppealPermissionsIssueSubredditName(modmail, username, context);
+    if (appealPermissionsIssueSubredditName) {
+        await context.reddit.modMail.reply({
+            body: getAppealPermissionsIssueReply(appealPermissionsIssueSubredditName),
+            conversationId: modmail.conversationId,
+            isInternal: false,
+            isAuthorHidden: false,
+        });
+    }
+
+    const appealOutcomeType = await handleAppeal(modmail, currentStatus, context, {
+        suppressDefaultReply: appealPermissionsIssueSubredditName !== undefined,
+    });
 
     if (appealOutcomeType !== AppealOutcomeType.AppealGranted) {
         await addSummaryForUser(modmail.conversationId, username, context);
@@ -314,6 +328,50 @@ async function handleModmailFromUser (modmail: ModmailMessage, context: TriggerC
     }
 
     await context.redis.set(recentAppealKey, new Date().getTime().toString(), { expiration: addDays(new Date(), 1) });
+}
+
+function getAppealSubredditName (subject: string, username: string): string | undefined {
+    const appealSubjectRegex = new RegExp(`^Ban dispute for /u/${username} on /r/([A-Za-z0-9_]+)\\s*$`, "i");
+    return appealSubjectRegex.exec(subject)?.[1];
+}
+
+async function getAppealPermissionsIssueSubredditName (modmail: ModmailMessage, username: string, context: TriggerContext): Promise<string | undefined> {
+    const subredditName = getAppealSubredditName(modmail.subject, username);
+    if (!subredditName) {
+        return;
+    }
+
+    let isMod: boolean;
+    try {
+        isMod = await isModeratorWithCache(context.appSlug, context, subredditName);
+    } catch (error) {
+        console.error(`Appeals: Unable to check whether /u/${context.appSlug} is a moderator of /r/${subredditName}:`, error instanceof Error ? error.message : String(error));
+        return;
+    }
+
+    if (!isMod) {
+        return subredditName;
+    }
+
+    try {
+        const hasPerms = await hasPermissions(context.reddit, {
+            subredditName,
+            username: context.appSlug,
+            requiredPerms: REQUIRED_BOT_PERMISSIONS,
+        });
+        return hasPerms ? undefined : subredditName;
+    } catch (error) {
+        console.error(`Appeals: Unable to confirm /u/${context.appSlug} permissions in /r/${subredditName}:`, error instanceof Error ? error.message : String(error));
+        return subredditName;
+    }
+}
+
+function getAppealPermissionsIssueReply (subredditName: string): string {
+    return `Your appeal has been received. Upon initial review, the Bot Bouncer app moderator account, /u/bot-bouncer, may not currently have the moderator permissions needed to manage bans in /r/${subredditName}.
+
+Your classification can still be reviewed by /r/BotBouncer, but any accepted appeal will not take effect in /r/${subredditName} until that subreddit’s mod team restores Bot Bouncer with full moderator permissions.
+
+We will review your appeal as soon as we can.`;
 }
 
 function getKeyForAppeal (conversationId: string): string {


### PR DESCRIPTION
## Summary

This adds an appeal-specific permissions check for generated ban-dispute modmail subjects. When an appellant files an appeal for a subreddit where `/u/bot-bouncer` is not on the mod team or lacks required permissions, Bot Bouncer sends a short acknowledgement explaining that the appeal can still be reviewed, but an accepted appeal may not take effect in that subreddit until permissions are restored.

The subject check is anchored to the generated appeal format so the message is not sent merely because a user mentions a subreddit in the modmail title.

## Appellant message

```text
Your appeal has been received. Upon initial review, the Bot Bouncer app moderator account, /u/bot-bouncer, may not currently have the moderator permissions needed to manage bans in /r/${subredditName}.

Your classification can still be reviewed by /r/BotBouncer, but any accepted appeal will not take effect in /r/${subredditName} until that subreddit’s mod team restores Bot Bouncer with full moderator permissions.

We will review your appeal as soon as we can.
```

## Testing

- `git diff --check`
- `npm.cmd run test:unit`