### PR TITLE
Track automatic appeal denials

### DIFF
--- a/src/modmail/appealOutcomes.ts
+++ b/src/modmail/appealOutcomes.ts
@@ -1,0 +1,3 @@
+export enum AppealTrackedOutcome {
+    AutomaticDenial = "automaticDenial",
+}

--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -17,6 +17,7 @@ import { getPossibleSetStatusValues } from "./controlSubModmail.js";
 import { getUserSocialLinks } from "devvit-helpers";
 import { sendMessageOnDelay } from "./delayedSend.js";
 import { getEvaluatorVariables } from "../userEvaluation/evaluatorVariables.js";
+import { AppealTrackedOutcome } from "./appealOutcomes.js";
 
 const APPEAL_CONFIG_WIKI_PAGE = "appeal-config";
 const APPEAL_CONFIG_REDIS_KEY = "AppealConfig";
@@ -56,9 +57,11 @@ interface AppealConfig {
     archive?: boolean;
     mute?: number;
     highlight?: boolean;
+    trackOutcome?: AppealTrackedOutcome;
 }
 
 const acceptableMuteDurations = [3, 7, 28];
+const acceptableTrackedOutcomes = Object.values(AppealTrackedOutcome);
 
 const dateRegex = /^\d{4}-\d{2}-\d{2}(?: \d{2}:\d{2})?$/;
 
@@ -107,6 +110,7 @@ const appealConfigSchema: JSONSchemaType<AppealConfig[]> = {
             archive: { type: "boolean", nullable: true },
             mute: { type: "number", enum: acceptableMuteDurations, nullable: true },
             highlight: { type: "boolean", nullable: true },
+            trackOutcome: { type: "string", enum: acceptableTrackedOutcomes, nullable: true },
         },
         additionalProperties: false,
         required: ["name"],
@@ -125,6 +129,7 @@ interface AppealOutcome {
     archive?: boolean;
     mute?: number;
     highlight?: boolean;
+    trackOutcome?: AppealTrackedOutcome;
 }
 
 const defaultAppealOutcome: AppealOutcome = {
@@ -219,6 +224,14 @@ export async function validateAndSaveAppealConfig (username: string, context: Tr
     }
 
     for (const config of parsedConfigs) {
+        if (config.trackOutcome === AppealTrackedOutcome.AutomaticDenial && !config.reply) {
+            issues.push(`Config ${config.name} tracks automatic denials but does not send a public reply.`);
+        }
+
+        if (config.trackOutcome === AppealTrackedOutcome.AutomaticDenial && config.setStatus) {
+            issues.push(`Config ${config.name} tracks automatic denials but also changes the user status.`);
+        }
+
         if (config.currentEvaluatorHitReasonRegex) {
             for (const regex of config.currentEvaluatorHitReasonRegex) {
                 try {
@@ -317,6 +330,7 @@ export enum AppealOutcomeType {
     Neutral = "neutral",
     StatusChanged = "statusChanged",
     AppealGranted = "appealGranted",
+    AutomaticDenial = "automaticDenial",
 }
 
 function isAppealGrantStatus (status: string | undefined): boolean {
@@ -564,7 +578,12 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
             archive: matchedAppealConfig.archive,
             mute: matchedAppealConfig.mute,
             highlight: matchedAppealConfig.highlight,
+            trackOutcome: matchedAppealConfig.trackOutcome,
         };
+
+        if (matchedAppealConfig.trackOutcome === AppealTrackedOutcome.AutomaticDenial) {
+            appealOutcomeType = AppealOutcomeType.AutomaticDenial;
+        }
     } else {
         console.log(`Appeals: No specific appeal config matched for user ${username}, using default reply.`);
         appealOutcome = defaultAppealOutcome;
@@ -608,6 +627,8 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 message: replyMessage,
                 archive: appealOutcome.archive,
                 sendAt,
+                trackOutcome: appealOutcome.trackOutcome,
+                trackedOutcomeName: appealOutcome.name,
             });
         } else {
             if (appealOutcome.mute) {
@@ -623,6 +644,8 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 message: replyMessage,
                 archive: appealOutcome.archive,
                 sendAt: addSeconds(new Date(), 20),
+                trackOutcome: appealOutcome.trackOutcome,
+                trackedOutcomeName: appealOutcome.name,
             });
         }
     }

--- a/src/modmail/delayedSend.ts
+++ b/src/modmail/delayedSend.ts
@@ -2,12 +2,16 @@ import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext } from "@devv
 import { addMinutes, addSeconds } from "date-fns";
 import json2md from "json2md";
 import { ControlSubredditJob } from "../constants.js";
+import { markAutomaticAppealDenial } from "../statistics/appealOutcomeStatistics.js";
+import { AppealTrackedOutcome } from "./appealOutcomes.js";
 
 interface DelayedMessageOptions {
     conversationId: string;
     message: string;
     sendAt: Date;
     archive?: boolean;
+    trackOutcome?: AppealTrackedOutcome;
+    trackedOutcomeName?: string;
 }
 
 const DELAYED_MESSAGE_QUEUE = "delayedMessageQueue";
@@ -19,6 +23,8 @@ export async function sendMessageOnDelay (context: TriggerContext, params: Delay
             isAuthorHidden: true,
             body: params.message,
         });
+
+        await markTrackedOutcome(params, context);
 
         if (params.archive) {
             await context.reddit.modMail.archiveConversation(params.conversationId);
@@ -67,6 +73,8 @@ export async function processDelayedMessages (event: ScheduledJobEvent<JSONObjec
         body: firstMessage.message,
     });
 
+    await markTrackedOutcome(firstMessage, context);
+
     if (firstMessage.archive) {
         await context.reddit.modMail.archiveConversation(firstMessage.conversationId);
     }
@@ -82,6 +90,12 @@ export async function processDelayedMessages (event: ScheduledJobEvent<JSONObjec
     }
 
     console.log(`Delayed Messages: Processed message for conversation ${firstMessage.conversationId}`);
+}
+
+async function markTrackedOutcome (params: DelayedMessageOptions, context: TriggerContext | JobContext) {
+    if (params.trackOutcome === AppealTrackedOutcome.AutomaticDenial && params.trackedOutcomeName) {
+        await markAutomaticAppealDenial(params.trackedOutcomeName, context);
+    }
 }
 
 export async function areAnyDelayedMessagesQueued (context: JobContext) {

--- a/src/scheduler/fiveMinutelyJobs.ts
+++ b/src/scheduler/fiveMinutelyJobs.ts
@@ -4,6 +4,7 @@ import { processHighlightedModmailQueue } from "../modmail/unhighlighter.js";
 import { gatherTokenStatistics } from "../aiAnalysis/statistics.js";
 import { updateClassificationStatistics } from "../statistics/classificationStatistics.js";
 import { updateAppealStatistics } from "../statistics/appealStatistics.js";
+import { updateAppealOutcomeStatistics } from "../statistics/appealOutcomeStatistics.js";
 
 export async function handleFiveMinutelyJob (_: unknown, context: JobContext) {
     if (context.subredditName !== CONTROL_SUBREDDIT) {
@@ -33,5 +34,6 @@ export async function handleFiveMinutelyJob (_: unknown, context: JobContext) {
         gatherTokenStatistics(context),
         updateClassificationStatistics(context),
         updateAppealStatistics(context),
+        updateAppealOutcomeStatistics(context),
     ]);
 }

--- a/src/statistics/appealOutcomeStatistics.ts
+++ b/src/statistics/appealOutcomeStatistics.ts
@@ -1,0 +1,95 @@
+import { JobContext, TriggerContext } from "@devvit/public-api";
+import { addHours, eachDayOfInterval, format, startOfDay, subDays } from "date-fns";
+import json2md from "json2md";
+import { AppealTrackedOutcome } from "../modmail/appealOutcomes.js";
+
+function getAutomaticDenialKeyForDate (date = new Date()): string {
+    return `appealOutcomeStatistics~${AppealTrackedOutcome.AutomaticDenial}~${format(date, "yyyy-MM-dd")}`;
+}
+
+export async function markAutomaticAppealDenial (configName: string, context: TriggerContext | JobContext) {
+    const count = await context.redis.zIncrBy(getAutomaticDenialKeyForDate(), configName, 1);
+    console.log(`Appeals: Automatic denial tracked for ${configName}. Total for this rule today: ${count}`);
+}
+
+function aggregateSortedSetData (data: { member: string; score: number }[][]): Record<string, number> {
+    const results: Record<string, number> = {};
+    for (const { member, score } of data.flat()) {
+        if (!results[member]) {
+            results[member] = 0;
+        }
+        results[member] += score;
+    }
+    return results;
+}
+
+function pushAutomaticDenialTable (wikiContent: json2md.DataObject[], heading: string, data: Record<string, number>, emptyMessage: string) {
+    wikiContent.push({ h2: heading });
+
+    if (Object.keys(data).length === 0) {
+        wikiContent.push({ p: emptyMessage });
+        return;
+    }
+
+    const headers = ["Appeal config", "Automatic denials"];
+    const rows = Object.entries(data)
+        .sort(([, a], [, b]) => b - a)
+        .map(([configName, count]) => [configName, count.toLocaleString()]);
+    wikiContent.push({ table: { headers, rows } });
+}
+
+export async function updateAppealOutcomeStatistics (context: JobContext) {
+    const runRecentlyKey = "appealOutcomeStatisticsRunRecently";
+    if (await context.redis.exists(runRecentlyKey)) {
+        return;
+    }
+    await context.redis.set(runRecentlyKey, Date.now().toString(), { expiration: addHours(new Date(), 1) });
+
+    const startDate = startOfDay(subDays(new Date(), 7));
+    const endDate = startOfDay(subDays(new Date(), 1));
+    const dayToDelete = subDays(new Date(), 8);
+    const allDaysInRange = eachDayOfInterval({ start: startDate, end: endDate });
+
+    await context.redis.del(getAutomaticDenialKeyForDate(dayToDelete));
+
+    const allAutomaticDenialData = await Promise.all(allDaysInRange.map(day => context.redis.zRange(getAutomaticDenialKeyForDate(day), 0, -1)));
+    const automaticDenialData = aggregateSortedSetData(allAutomaticDenialData);
+
+    const wikiContent: json2md.DataObject[] = [
+        { h1: "Appeal outcome statistics" },
+        { p: "This lists tracked automatic appeal outcomes from the last week." },
+        { p: "Only appeal config entries with `trackOutcome: automaticDenial` are counted." },
+    ];
+
+    pushAutomaticDenialTable(
+        wikiContent,
+        "Automatic denials in the last 7 days",
+        automaticDenialData,
+        "No automatic denials were tracked in the last week.",
+    );
+
+    const yesterdayData = await context.redis.zRange(getAutomaticDenialKeyForDate(subDays(new Date(), 1)), 0, -1);
+    pushAutomaticDenialTable(
+        wikiContent,
+        "Yesterday's automatic denials (UTC)",
+        aggregateSortedSetData([yesterdayData]),
+        "No automatic denials were tracked yesterday.",
+    );
+
+    const todayData = await context.redis.zRange(getAutomaticDenialKeyForDate(), 0, -1);
+    pushAutomaticDenialTable(
+        wikiContent,
+        "Today's automatic denials since midnight UTC",
+        aggregateSortedSetData([todayData]),
+        "No automatic denials have been tracked today.",
+    );
+
+    wikiContent.push({ p: "This page updates every hour, and may update more frequently." });
+
+    const subredditName = context.subredditName ?? await context.reddit.getCurrentSubredditName();
+    await context.reddit.updateWikiPage({
+        subredditName,
+        page: "statistics/appealoutcomes",
+        content: json2md(wikiContent),
+    });
+}


### PR DESCRIPTION
## Summary

Adds `trackOutcome: automaticDenial` as an optional appeal config property for tracking automated appeal-denial statistics.

## Changes

* Adds support for `trackOutcome: automaticDenial` in appeal config entries.
* Records automatic-denial outcomes when a tracked public reply is actually sent.
* Supports both immediate replies and delayed replies without counting scheduled-but-unsent denials.
* Adds appeal-outcome statistics so automated denial volume can be reviewed over time.
* Validates tracked automatic-denial configs to ensure they send a public reply and do not also change account status.

## Rationale

Some appeal config entries automatically deny appeals, but those outcomes were previously indistinguishable from other neutral automated replies. The new `trackOutcome: automaticDenial` property makes denial rules explicit and measurable, allowing the team to track how many appeals are being resolved through automated denial rather than manual review. This should make appeal workload statistics more accurate and help evaluate whether automated denial rules are meaningfully reducing moderator burden.

## Tests

* `npm.cmd run test:unit`
* 10 test files passed
* 44 tests passed