### PR TITLE
Add negated appeal config regex filters

### DIFF
--- a/src/modmail/appealConfigRegex.test.ts
+++ b/src/modmail/appealConfigRegex.test.ts
@@ -9,16 +9,23 @@ const supportedRegexProperties = [
     "usernameRegex",
     "~usernameRegex",
     "messageBodyRegex",
+    "~messageBodyRegex",
     "evaluatorNameRegex",
+    "~evaluatorNameRegex",
     "evaluatorHitReasonRegex",
+    "~evaluatorHitReasonRegex",
     "currentEvaluatorNameRegex",
+    "~currentEvaluatorNameRegex",
     "currentEvaluatorHitReasonRegex",
+    "~currentEvaluatorHitReasonRegex",
     "bioRegex",
     "~bioRegex",
     "originalBioRegex",
+    "~originalBioRegex",
     "socialLinkRegex",
     "~socialLinkRegex",
     "originalSocialLinkRegex",
+    "~originalSocialLinkRegex",
     "modNoteTextRegex",
     "~modNoteTextRegex",
 ];
@@ -93,14 +100,16 @@ test("reports the invalid array position without including valid expressions", (
 
 test("uses the same flags during validation and matching", () => {
     const config = compileAppealConfigRegexes({
-        name: "Flags test",
-        usernameRegex: ["^example$"],
-        bioRegex: ["^café$"],
-        modNoteTextRegex: ["^CaseSensitive$"],
+        "name": "Flags test",
+        "usernameRegex": ["^example$"],
+        "bioRegex": ["^café$"],
+        "~originalBioRegex": ["^café$"],
+        "modNoteTextRegex": ["^CaseSensitive$"],
     });
 
     expect(config.compiledRegexes.usernameRegex?.[0].test("EXAMPLE")).toBe(true);
     expect(config.compiledRegexes.bioRegex?.[0].test("CAFÉ")).toBe(true);
+    expect(config.compiledRegexes["~originalBioRegex"]?.[0].test("CAFÉ")).toBe(true);
     expect(config.compiledRegexes.modNoteTextRegex?.[0].test("casesensitive")).toBe(false);
 });
 

--- a/src/modmail/appealConfigRegex.ts
+++ b/src/modmail/appealConfigRegex.ts
@@ -3,16 +3,23 @@ export interface AppealRegexConfig {
     "usernameRegex"?: string[];
     "~usernameRegex"?: string[];
     "messageBodyRegex"?: string[];
+    "~messageBodyRegex"?: string[];
     "evaluatorNameRegex"?: string[];
+    "~evaluatorNameRegex"?: string[];
     "evaluatorHitReasonRegex"?: string[];
+    "~evaluatorHitReasonRegex"?: string[];
     "currentEvaluatorNameRegex"?: string[];
+    "~currentEvaluatorNameRegex"?: string[];
     "currentEvaluatorHitReasonRegex"?: string[];
+    "~currentEvaluatorHitReasonRegex"?: string[];
     "bioRegex"?: string[];
     "~bioRegex"?: string[];
     "originalBioRegex"?: string[];
+    "~originalBioRegex"?: string[];
     "socialLinkRegex"?: string[];
     "~socialLinkRegex"?: string[];
     "originalSocialLinkRegex"?: string[];
+    "~originalSocialLinkRegex"?: string[];
     "modNoteTextRegex"?: string[];
     "~modNoteTextRegex"?: string[];
 }
@@ -23,6 +30,7 @@ const appealRegexFlags: Partial<Record<AppealRegexProperty, string>> = {
     "bioRegex": "iu",
     "~bioRegex": "iu",
     "originalBioRegex": "iu",
+    "~originalBioRegex": "iu",
     "modNoteTextRegex": "u",
     "~modNoteTextRegex": "u",
 };

--- a/src/modmail/autoAppealHandling.test.ts
+++ b/src/modmail/autoAppealHandling.test.ts
@@ -1,0 +1,221 @@
+import type { EvaluationResult } from "../handleControlSubAccountEvaluation.js";
+import {
+    type AppealRegexConfig,
+    type AppealRegexProperty,
+    type CompiledAppealRegexes,
+    compileAppealConfigRegexes,
+} from "./appealConfigRegex.js";
+import {
+    evaluationResultMatchesRegexes,
+    negatedAppealRegexesExcludeConfig,
+    type NegatedAppealRegexContext,
+} from "./autoAppealHandling.js";
+
+function evaluationResult (botName: string, hitReason?: string | { reason: string }): EvaluationResult {
+    return {
+        botName,
+        hitReason: hitReason as EvaluationResult["hitReason"],
+        canAutoBan: true,
+        metThreshold: true,
+    };
+}
+
+function compiledRegexesFor (
+    property: AppealRegexProperty,
+    values: string[],
+): CompiledAppealRegexes {
+    const config = {
+        name: "test",
+        [property]: values,
+    } as AppealRegexConfig;
+
+    return compileAppealConfigRegexes(config).compiledRegexes;
+}
+
+const emptyNegatedContext: NegatedAppealRegexContext = {
+    messageBody: "ordinary appeal",
+    initialEvaluationResults: [],
+    currentEvaluationResults: [],
+    originalBio: undefined,
+    originalSocialLinks: [],
+};
+
+test("evaluation result regex matching combines evaluator and hit reason", () => {
+    const result = evaluationResult(
+        "Bot Group Advanced",
+        "Future Laura account",
+    );
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Bot Group Advanced$/i],
+        [/Future Laura/i],
+    )).toBe(true);
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Social Links Bot$/i],
+        [/Future Laura/i],
+    )).toBe(false);
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Bot Group Advanced$/i],
+        [/Social Links/i],
+    )).toBe(false);
+});
+
+test("evaluation result regex matching supports structured hit reasons", () => {
+    const result = evaluationResult(
+        "Bot Group Advanced",
+        { reason: "Anime sole post bot" },
+    );
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Bot Group Advanced$/i],
+        [/Anime sole post/i],
+    )).toBe(true);
+});
+
+test("configured empty evaluator regex arrays match no evaluation results", () => {
+    const result = evaluationResult(
+        "Bot Group Advanced",
+        "Future Laura account",
+    );
+
+    expect(evaluationResultMatchesRegexes(result, [])).toBe(false);
+    expect(evaluationResultMatchesRegexes(result, undefined, [])).toBe(false);
+});
+
+test("matching negated appeal regexes exclude configs", () => {
+    const cases: {
+        property: AppealRegexProperty;
+        pattern: string;
+        context: NegatedAppealRegexContext;
+    }[] = [
+        {
+            property: "~messageBodyRegex",
+            pattern: "blocked",
+            context: {
+                ...emptyNegatedContext,
+                messageBody: "This appeal contains a blocked phrase.",
+            },
+        },
+        {
+            property: "~evaluatorNameRegex",
+            pattern: "blocked evaluator",
+            context: {
+                ...emptyNegatedContext,
+                initialEvaluationResults: [
+                    evaluationResult(
+                        "Blocked Evaluator",
+                        "ordinary reason",
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~evaluatorHitReasonRegex",
+            pattern: "blocked reason",
+            context: {
+                ...emptyNegatedContext,
+                initialEvaluationResults: [
+                    evaluationResult(
+                        "Ordinary Evaluator",
+                        "Blocked reason",
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~currentEvaluatorNameRegex",
+            pattern: "blocked evaluator",
+            context: {
+                ...emptyNegatedContext,
+                currentEvaluationResults: [
+                    evaluationResult(
+                        "Blocked Evaluator",
+                        "ordinary reason",
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~currentEvaluatorHitReasonRegex",
+            pattern: "blocked reason",
+            context: {
+                ...emptyNegatedContext,
+                currentEvaluationResults: [
+                    evaluationResult(
+                        "Ordinary Evaluator",
+                        { reason: "Blocked reason" },
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~originalBioRegex",
+            pattern: "blocked bio",
+            context: {
+                ...emptyNegatedContext,
+                originalBio: "This is a blocked bio.",
+            },
+        },
+        {
+            property: "~originalSocialLinkRegex",
+            pattern: "blocked-site",
+            context: {
+                ...emptyNegatedContext,
+                originalSocialLinks: [{
+                    outboundUrl: "https://blocked-site.example/profile",
+                }],
+            },
+        },
+    ];
+
+    for (const testCase of cases) {
+        const regexes = compiledRegexesFor(
+            testCase.property,
+            [testCase.pattern],
+        );
+
+        expect(negatedAppealRegexesExcludeConfig(
+            regexes,
+            testCase.context,
+        )).toBe(true);
+    }
+
+    expect(negatedAppealRegexesExcludeConfig(
+        compiledRegexesFor("~messageBodyRegex", ["blocked"]),
+        emptyNegatedContext,
+    )).toBe(false);
+});
+
+test("empty negated evaluator arrays do not exclude configs", () => {
+    const context: NegatedAppealRegexContext = {
+        ...emptyNegatedContext,
+        initialEvaluationResults: [
+            evaluationResult(
+                "Bot Group Advanced",
+                "Future Laura account",
+            ),
+        ],
+        currentEvaluationResults: [
+            evaluationResult(
+                "Bot Group Advanced",
+                "Future Laura account",
+            ),
+        ],
+    };
+
+    expect(negatedAppealRegexesExcludeConfig(
+        compiledRegexesFor("~evaluatorNameRegex", []),
+        context,
+    )).toBe(false);
+
+    expect(negatedAppealRegexesExcludeConfig(
+        compiledRegexesFor("~evaluatorHitReasonRegex", []),
+        context,
+    )).toBe(false);
+});

--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -17,7 +17,7 @@ import { getPossibleSetStatusValues } from "./controlSubModmail.js";
 import { getUserSocialLinks } from "devvit-helpers";
 import { sendMessageOnDelay } from "./delayedSend.js";
 import { getEvaluatorVariables } from "../userEvaluation/evaluatorVariables.js";
-import { AppealConfigWithCompiledRegexes, AppealRegexConfig, compileAppealConfigs, getAppealConfigRegexIssues } from "./appealConfigRegex.js";
+import { AppealConfigWithCompiledRegexes, AppealRegexConfig, type CompiledAppealRegexes, compileAppealConfigs, getAppealConfigRegexIssues } from "./appealConfigRegex.js";
 
 const APPEAL_CONFIG_WIKI_PAGE = "appeal-config";
 const APPEAL_CONFIG_REDIS_KEY = "AppealConfig";
@@ -64,18 +64,25 @@ const appealConfigSchema: JSONSchemaType<AppealConfig[]> = {
             usernameRegex: { type: "array", items: { type: "string" }, nullable: true },
             "~usernameRegex": { type: "array", items: { type: "string" }, nullable: true },
             messageBodyRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~messageBodyRegex": { type: "array", items: { type: "string" }, nullable: true },
             banDateFrom: { type: "string", pattern: dateRegex.source, nullable: true },
             banDateTo: { type: "string", pattern: dateRegex.source, nullable: true },
             evaluatorNameRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~evaluatorNameRegex": { type: "array", items: { type: "string" }, nullable: true },
             evaluatorHitReasonRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~evaluatorHitReasonRegex": { type: "array", items: { type: "string" }, nullable: true },
             currentEvaluatorNameRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~currentEvaluatorNameRegex": { type: "array", items: { type: "string" }, nullable: true },
             currentEvaluatorHitReasonRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~currentEvaluatorHitReasonRegex": { type: "array", items: { type: "string" }, nullable: true },
             bioRegex: { type: "array", items: { type: "string" }, nullable: true },
             "~bioRegex": { type: "array", items: { type: "string" }, nullable: true },
             originalBioRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~originalBioRegex": { type: "array", items: { type: "string" }, nullable: true },
             socialLinkRegex: { type: "array", items: { type: "string" }, nullable: true },
             "~socialLinkRegex": { type: "array", items: { type: "string" }, nullable: true },
             originalSocialLinkRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~originalSocialLinkRegex": { type: "array", items: { type: "string" }, nullable: true },
             flags: { type: "array", items: { type: "string", enum: Object.values(UserFlag) }, nullable: true },
             "~flags": { type: "array", items: { type: "string", enum: Object.values(UserFlag) }, nullable: true },
             modNoteTextRegex: { type: "array", items: { type: "string" }, nullable: true },
@@ -123,6 +130,116 @@ const defaultAppealOutcome: AppealOutcome = {
 
 If Bot Bouncer has banned you from more than one subreddit, you don't need to appeal separately.`,
 };
+
+function regexesMatchText (regexes: RegExp[] | undefined, text: string | undefined): boolean {
+    if (!regexes?.length || text === undefined) {
+        return false;
+    }
+
+    return regexes.some(regex => regex.test(text));
+}
+
+function evaluationHitReasonMatches (evaluationResult: EvaluationResult, regexes: RegExp[] | undefined): boolean {
+    if (!regexes?.length || !evaluationResult.hitReason) {
+        return false;
+    }
+
+    if (typeof evaluationResult.hitReason === "string") {
+        return regexesMatchText(regexes, evaluationResult.hitReason);
+    }
+
+    return regexesMatchText(regexes, evaluationResult.hitReason.reason);
+}
+
+export function evaluationResultMatchesRegexes (
+    evaluationResult: EvaluationResult,
+    evaluatorNameRegex?: RegExp[],
+    evaluatorHitReasonRegex?: RegExp[],
+): boolean {
+    if (evaluatorNameRegex !== undefined && !regexesMatchText(evaluatorNameRegex, evaluationResult.botName)) {
+        return false;
+    }
+
+    if (evaluatorHitReasonRegex !== undefined && !evaluationHitReasonMatches(evaluationResult, evaluatorHitReasonRegex)) {
+        return false;
+    }
+
+    return true;
+}
+
+function evaluationResultsContainMatch (
+    evaluationResults: EvaluationResult[],
+    evaluatorNameRegex?: RegExp[],
+    evaluatorHitReasonRegex?: RegExp[],
+): boolean {
+    return evaluationResults.some(evaluationResult => evaluationResultMatchesRegexes(
+        evaluationResult,
+        evaluatorNameRegex,
+        evaluatorHitReasonRegex,
+    ));
+}
+
+export interface NegatedAppealRegexContext {
+    messageBody: string;
+    initialEvaluationResults: EvaluationResult[];
+    currentEvaluationResults: EvaluationResult[];
+    originalBio: string | undefined;
+    originalSocialLinks: { outboundUrl: string }[];
+}
+
+export function negatedAppealRegexesExcludeConfig (
+    regexes: CompiledAppealRegexes,
+    context: NegatedAppealRegexContext,
+): boolean {
+    if (regexes["~messageBodyRegex"]?.some(regex => regex.test(context.messageBody))) {
+        return true;
+    }
+
+    const hasInitialEvaluatorNegation =
+        regexes["~evaluatorNameRegex"] !== undefined ||
+        regexes["~evaluatorHitReasonRegex"] !== undefined;
+
+    if (
+        hasInitialEvaluatorNegation &&
+        evaluationResultsContainMatch(
+            context.initialEvaluationResults,
+            regexes["~evaluatorNameRegex"],
+            regexes["~evaluatorHitReasonRegex"],
+        )
+    ) {
+        return true;
+    }
+
+    const hasCurrentEvaluatorNegation =
+        regexes["~currentEvaluatorNameRegex"] !== undefined ||
+        regexes["~currentEvaluatorHitReasonRegex"] !== undefined;
+
+    if (
+        hasCurrentEvaluatorNegation &&
+        evaluationResultsContainMatch(
+            context.currentEvaluationResults,
+            regexes["~currentEvaluatorNameRegex"],
+            regexes["~currentEvaluatorHitReasonRegex"],
+        )
+    ) {
+        return true;
+    }
+
+    if (
+        context.originalBio &&
+        regexes["~originalBioRegex"]?.some(regex => regex.test(context.originalBio ?? ""))
+    ) {
+        return true;
+    }
+
+    if (
+        regexes["~originalSocialLinkRegex"]?.some(regex => context.originalSocialLinks.some(link => regex.test(link.outboundUrl)))
+    ) {
+        return true;
+    }
+
+    return false;
+}
 
 function getSubstitutions (wikiPage: string): Record<string, string | string[]> {
     const documents = parseAllDocuments(wikiPage);
@@ -334,8 +451,13 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
     }
 
     let currentEvaluationResults: EvaluationResult[] = [];
-    if (appealConfig.some(config => (config.compiledRegexes.currentEvaluatorHitReasonRegex?.length ?? 0) > 0
-        || (config.compiledRegexes.currentEvaluatorNameRegex?.length ?? 0) > 0)) {
+
+    if (appealConfig.some(config => [
+        config.compiledRegexes.currentEvaluatorHitReasonRegex,
+        config.compiledRegexes.currentEvaluatorNameRegex,
+        config.compiledRegexes["~currentEvaluatorHitReasonRegex"],
+        config.compiledRegexes["~currentEvaluatorNameRegex"],
+    ].some(regexes => (regexes?.length ?? 0) > 0))) {
         currentEvaluationResults = await evaluateUserAccount({
             username,
             variables: await getEvaluatorVariables(context),
@@ -355,6 +477,16 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
     const matchedAppealConfig = appealConfig.find((config) => {
         try {
             const regexes = config.compiledRegexes;
+
+            if (negatedAppealRegexesExcludeConfig(regexes, {
+                messageBody: modmail.bodyMarkdown,
+                initialEvaluationResults: initialAccountEvaluationResults,
+                currentEvaluationResults,
+                originalBio,
+                originalSocialLinks,
+            })) {
+                return;
+            }
 
             if (regexes.usernameRegex && !regexes.usernameRegex.some(regex => regex.test(username))) {
                 return;
@@ -384,58 +516,22 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 return;
             }
 
-            if (regexes.evaluatorNameRegex || regexes.evaluatorHitReasonRegex) {
-                let anyMatched = false;
-                for (const evaluationResult of initialAccountEvaluationResults) {
-                    if (regexes.evaluatorNameRegex && !regexes.evaluatorNameRegex.some(regex => regex.test(evaluationResult.botName))) {
-                        continue;
-                    }
-
-                    if (regexes.evaluatorHitReasonRegex && !regexes.evaluatorHitReasonRegex.some((regex) => {
-                        if (!evaluationResult.hitReason) {
-                            return false;
-                        }
-
-                        if (typeof evaluationResult.hitReason === "string") {
-                            return regex.test(evaluationResult.hitReason);
-                        }
-
-                        return regex.test(evaluationResult.hitReason.reason);
-                    })) {
-                        continue;
-                    }
-                    anyMatched = true;
-                }
-
-                if (!anyMatched) {
+            if (regexes.evaluatorNameRegex !== undefined || regexes.evaluatorHitReasonRegex !== undefined) {
+                if (!evaluationResultsContainMatch(
+                    initialAccountEvaluationResults,
+                    regexes.evaluatorNameRegex,
+                    regexes.evaluatorHitReasonRegex,
+                )) {
                     return;
                 }
             }
 
-            if (regexes.currentEvaluatorNameRegex || regexes.currentEvaluatorHitReasonRegex) {
-                let anyMatched = false;
-                for (const evaluationResult of currentEvaluationResults) {
-                    if (regexes.currentEvaluatorNameRegex && !regexes.currentEvaluatorNameRegex.some(regex => regex.test(evaluationResult.botName))) {
-                        continue;
-                    }
-
-                    if (regexes.currentEvaluatorHitReasonRegex && !regexes.currentEvaluatorHitReasonRegex.some((regex) => {
-                        if (!evaluationResult.hitReason) {
-                            return false;
-                        }
-
-                        if (typeof evaluationResult.hitReason === "string") {
-                            return regex.test(evaluationResult.hitReason);
-                        }
-
-                        return regex.test(evaluationResult.hitReason.reason);
-                    })) {
-                        continue;
-                    }
-                    anyMatched = true;
-                }
-
-                if (!anyMatched) {
+            if (regexes.currentEvaluatorNameRegex !== undefined || regexes.currentEvaluatorHitReasonRegex !== undefined) {
+                if (!evaluationResultsContainMatch(
+                    currentEvaluationResults,
+                    regexes.currentEvaluatorNameRegex,
+                    regexes.currentEvaluatorHitReasonRegex,
+                )) {
                     return;
                 }
             }


### PR DESCRIPTION
## Summary

Adds negated appeal-config regex filters for fields that previously supported only positive matching.

## Dependency

This is a stacked pull request based on `validate-precompile-appeal-regexes` and should be merged after PR #497.

After #497 merges, this PR should be rebased onto and retargeted to `main`.

## Changes

- Adds support for:
  - `~messageBodyRegex`
  - `~evaluatorNameRegex`
  - `~evaluatorHitReasonRegex`
  - `~currentEvaluatorNameRegex`
  - `~currentEvaluatorHitReasonRegex`
  - `~originalBioRegex`
  - `~originalSocialLinkRegex`
- Registers the new fields in the centralized appeal-regex registry introduced by PR #497.
- Validates and precompiles negated expressions using the same flags as their positive counterparts.
- Excludes an appeal config when a negated expression matches.
- Ensures evaluator-name and hit-reason expressions match the same evaluation result.
- Loads current evaluation results when positive or negated current-evaluator filters are configured.
- Preserves existing positive matching behavior.

## Tests

Regression coverage includes:

- registry and validation coverage for each new negated field;
- combined evaluator-name and hit-reason matching;
- structured evaluator hit reasons; and
- compilation through the centralized regex registry.

## Validation

```powershell
npm.cmd exec -- tsc --noEmit
npm.cmd exec -- eslint .
npm.cmd test
```
