### PR TITLE
Track resolved automated appeal outcomes

### DIFF
--- a/src/modmail/appealOutcomeTracking.test.ts
+++ b/src/modmail/appealOutcomeTracking.test.ts
@@ -1,0 +1,66 @@
+import { UserStatus } from "../dataStore.js";
+import { AppealTrackedOutcome, getAppealOutcomeTrackingIssues } from "./appealOutcomeTracking.js";
+
+test("accepts a fully resolving automatic grant config", () => {
+    const issues = getAppealOutcomeTrackingIssues({
+        name: "Grant recovered accounts",
+        setStatus: UserStatus.Organic,
+        reply: "Your appeal was granted.",
+        archive: true,
+        trackOutcome: AppealTrackedOutcome.AutomaticGrant,
+    });
+
+    expect(issues).toEqual([]);
+});
+
+test("accepts a fully resolving automatic denial config", () => {
+    const issues = getAppealOutcomeTrackingIssues({
+        name: "Deny ineligible appeals",
+        reply: "Your appeal was denied.",
+        archive: true,
+        trackOutcome: AppealTrackedOutcome.AutomaticDenial,
+    });
+
+    expect(issues).toEqual([]);
+});
+
+test("requires tracked outcomes to send a public reply and archive the conversation", () => {
+    const issues = getAppealOutcomeTrackingIssues({
+        name: "Incomplete grant",
+        setStatus: UserStatus.Organic,
+        trackOutcome: AppealTrackedOutcome.AutomaticGrant,
+    });
+
+    expect(issues).toEqual([
+        "Appeal config Incomplete grant uses trackOutcome but does not define a public reply.",
+        "Appeal config Incomplete grant uses trackOutcome but does not set archive: true.",
+    ]);
+});
+
+test("requires automatic grants to set a grant-producing status", () => {
+    const issues = getAppealOutcomeTrackingIssues({
+        name: "Invalid grant",
+        setStatus: UserStatus.Banned,
+        reply: "Your appeal was granted.",
+        archive: true,
+        trackOutcome: AppealTrackedOutcome.AutomaticGrant,
+    });
+
+    expect(issues).toEqual([
+        "Appeal config Invalid grant tracks an automatic grant but does not set a grant-producing status.",
+    ]);
+});
+
+test("rejects denial tracking when the config grants the appeal", () => {
+    const issues = getAppealOutcomeTrackingIssues({
+        name: "Conflicting denial",
+        setStatus: UserStatus.Organic,
+        reply: "Your appeal was denied.",
+        archive: true,
+        trackOutcome: AppealTrackedOutcome.AutomaticDenial,
+    });
+
+    expect(issues).toEqual([
+        "Appeal config Conflicting denial tracks an automatic denial but sets a grant-producing status.",
+    ]);
+});

--- a/src/modmail/appealOutcomeTracking.ts
+++ b/src/modmail/appealOutcomeTracking.ts
@@ -1,0 +1,49 @@
+import { UserFlag, UserStatus } from "../dataStore.js";
+
+export enum AppealTrackedOutcome {
+    AutomaticDenial = "automaticDenial",
+    AutomaticGrant = "automaticGrant",
+}
+
+export interface AppealOutcomeTrackingConfig {
+    name: string;
+    setStatus?: string;
+    reply?: string;
+    archive?: boolean;
+    trackOutcome?: AppealTrackedOutcome;
+}
+
+export function isAppealGrantStatus (status: string | undefined): boolean {
+    return status === UserStatus.Organic
+        || status === UserFlag.HackedAndRecovered
+        || status === UserFlag.Scammed
+        || status === UserFlag.FutureNSFW;
+}
+
+export function getAppealOutcomeTrackingIssues (config: AppealOutcomeTrackingConfig): string[] {
+    if (!config.trackOutcome) {
+        return [];
+    }
+
+    const issues: string[] = [];
+    const configLabel = `Appeal config ${config.name}`;
+
+    if (!config.reply) {
+        issues.push(`${configLabel} uses trackOutcome but does not define a public reply.`);
+    }
+
+    if (config.archive !== true) {
+        issues.push(`${configLabel} uses trackOutcome but does not set archive: true.`);
+    }
+
+    const grantsAppeal = isAppealGrantStatus(config.setStatus);
+    if (config.trackOutcome === AppealTrackedOutcome.AutomaticGrant && !grantsAppeal) {
+        issues.push(`${configLabel} tracks an automatic grant but does not set a grant-producing status.`);
+    }
+
+    if (config.trackOutcome === AppealTrackedOutcome.AutomaticDenial && grantsAppeal) {
+        issues.push(`${configLabel} tracks an automatic denial but sets a grant-producing status.`);
+    }
+
+    return issues;
+}

--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -13,10 +13,12 @@ import { evaluateUserAccount, EvaluationResult, getAccountInitialEvaluationResul
 import { getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
 import { statusToFlair } from "../postCreation.js";
 import { addMinutes, addSeconds, differenceInMonths, format, getYear } from "date-fns";
-import { getPossibleSetStatusValues } from "./controlSubModmail.js";
+import { getKeyForAppeal, getPossibleSetStatusValues } from "./controlSubModmail.js";
 import { getUserSocialLinks } from "devvit-helpers";
 import { sendMessageOnDelay } from "./delayedSend.js";
 import { getEvaluatorVariables } from "../userEvaluation/evaluatorVariables.js";
+import { AppealTrackedOutcome, getAppealOutcomeTrackingIssues, isAppealGrantStatus } from "./appealOutcomeTracking.js";
+import { DelayedMessageCompletionAction } from "./delayedMessageCompletion.js";
 
 const APPEAL_CONFIG_WIKI_PAGE = "appeal-config";
 const APPEAL_CONFIG_REDIS_KEY = "AppealConfig";
@@ -56,9 +58,11 @@ interface AppealConfig {
     archive?: boolean;
     mute?: number;
     highlight?: boolean;
+    trackOutcome?: AppealTrackedOutcome;
 }
 
 const acceptableMuteDurations = [3, 7, 28];
+const acceptableTrackedOutcomes = Object.values(AppealTrackedOutcome);
 
 const dateRegex = /^\d{4}-\d{2}-\d{2}(?: \d{2}:\d{2})?$/;
 
@@ -107,6 +111,7 @@ const appealConfigSchema: JSONSchemaType<AppealConfig[]> = {
             archive: { type: "boolean", nullable: true },
             mute: { type: "number", enum: acceptableMuteDurations, nullable: true },
             highlight: { type: "boolean", nullable: true },
+            trackOutcome: { type: "string", enum: acceptableTrackedOutcomes, nullable: true },
         },
         additionalProperties: false,
         required: ["name"],
@@ -125,6 +130,7 @@ interface AppealOutcome {
     archive?: boolean;
     mute?: number;
     highlight?: boolean;
+    trackOutcome?: AppealTrackedOutcome;
 }
 
 const defaultAppealOutcome: AppealOutcome = {
@@ -219,6 +225,8 @@ export async function validateAndSaveAppealConfig (username: string, context: Tr
     }
 
     for (const config of parsedConfigs) {
+        issues.push(...getAppealOutcomeTrackingIssues(config));
+
         if (config.currentEvaluatorHitReasonRegex) {
             for (const regex of config.currentEvaluatorHitReasonRegex) {
                 try {
@@ -319,11 +327,21 @@ export enum AppealOutcomeType {
     AppealGranted = "appealGranted",
 }
 
-function isAppealGrantStatus (status: string | undefined): boolean {
-    return status === UserStatus.Organic
-        || status === UserFlag.HackedAndRecovered
-        || status === UserFlag.Scammed
-        || status === UserFlag.FutureNSFW;
+function getTrackedAppealCompletionAction (
+    appealOutcome: AppealOutcome,
+    conversationId: string,
+): DelayedMessageCompletionAction | undefined {
+    if (!appealOutcome.trackOutcome || appealOutcome.archive !== true || !appealOutcome.reply) {
+        return;
+    }
+
+    return {
+        type: "recordAppealOutcome",
+        outcome: appealOutcome.trackOutcome,
+        configName: appealOutcome.name,
+        conversationId,
+        activeAppealKey: getKeyForAppeal(conversationId),
+    };
 }
 
 export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDetails, context: TriggerContext): Promise<AppealOutcomeType> {
@@ -564,6 +582,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
             archive: matchedAppealConfig.archive,
             mute: matchedAppealConfig.mute,
             highlight: matchedAppealConfig.highlight,
+            trackOutcome: matchedAppealConfig.trackOutcome,
         };
     } else {
         console.log(`Appeals: No specific appeal config matched for user ${username}, using default reply.`);
@@ -593,6 +612,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
 
     if (appealOutcome.reply) {
         let replyMessage = `${formatPlaceholders(appealOutcome.reply, userDetails)}\n\n`;
+        const completionAction = getTrackedAppealCompletionAction(appealOutcome, modmail.conversationId);
 
         if (appealOutcome.replyDelay) {
             let sendAt: Date;
@@ -608,6 +628,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 message: replyMessage,
                 archive: appealOutcome.archive,
                 sendAt,
+                completionAction,
             });
         } else {
             if (appealOutcome.mute) {
@@ -623,6 +644,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 message: replyMessage,
                 archive: appealOutcome.archive,
                 sendAt: addSeconds(new Date(), 20),
+                completionAction,
             });
         }
     }

--- a/src/modmail/controlSubModmail.ts
+++ b/src/modmail/controlSubModmail.ts
@@ -309,7 +309,7 @@ async function handleModmailFromUser (modmail: ModmailMessage, context: TriggerC
     await context.redis.set(recentAppealKey, new Date().getTime().toString(), { expiration: addDays(new Date(), 1) });
 }
 
-function getKeyForAppeal (conversationId: string): string {
+export function getKeyForAppeal (conversationId: string): string {
     return `appeal~${conversationId}`;
 }
 

--- a/src/modmail/delayedMessageCompletion.ts
+++ b/src/modmail/delayedMessageCompletion.ts
@@ -1,0 +1,44 @@
+import { JobContext, TriggerContext } from "@devvit/public-api";
+import { AppealTrackedOutcome } from "./appealOutcomeTracking.js";
+import { markTrackedAppealOutcome } from "../statistics/appealOutcomeStatistics.js";
+
+export interface RecordAppealOutcomeCompletionAction {
+    type: "recordAppealOutcome";
+    outcome: AppealTrackedOutcome;
+    configName: string;
+    conversationId: string;
+    activeAppealKey: string;
+}
+
+export type DelayedMessageCompletionAction = RecordAppealOutcomeCompletionAction;
+
+export async function isDelayedMessageCompletionRelevant (
+    action: DelayedMessageCompletionAction,
+    context: TriggerContext | JobContext,
+): Promise<boolean> {
+    return await context.redis.exists(action.activeAppealKey) > 0;
+}
+
+export async function runDelayedMessageCompletion (
+    action: DelayedMessageCompletionAction,
+    context: TriggerContext | JobContext,
+): Promise<void> {
+    if (!await isDelayedMessageCompletionRelevant(action, context)) {
+        return;
+    }
+
+    try {
+        await markTrackedAppealOutcome(
+            action.outcome,
+            action.configName,
+            action.conversationId,
+            context,
+        );
+        await context.redis.del(action.activeAppealKey);
+    } catch (error) {
+        console.error(
+            `Failed to complete tracked appeal outcome for ${action.configName}:`,
+            error instanceof Error ? error.message : String(error),
+        );
+    }
+}

--- a/src/modmail/delayedSend.test.ts
+++ b/src/modmail/delayedSend.test.ts
@@ -1,0 +1,103 @@
+const { isDelayedMessageCompletionRelevantMock, runDelayedMessageCompletionMock } = vi.hoisted(() => ({
+    isDelayedMessageCompletionRelevantMock: vi.fn(),
+    runDelayedMessageCompletionMock: vi.fn(),
+}));
+
+vi.mock("./delayedMessageCompletion.js", () => ({
+    isDelayedMessageCompletionRelevant: isDelayedMessageCompletionRelevantMock,
+    runDelayedMessageCompletion: runDelayedMessageCompletionMock,
+}));
+
+import { JobContext, TriggerContext } from "@devvit/public-api";
+import { AppealTrackedOutcome } from "./appealOutcomeTracking.js";
+import { processDelayedMessages, sendMessageOnDelay } from "./delayedSend.js";
+
+const completionAction = {
+    type: "recordAppealOutcome" as const,
+    outcome: AppealTrackedOutcome.AutomaticDenial,
+    configName: "Denial rule",
+    conversationId: "conversation-1",
+    activeAppealKey: "appeal~conversation-1",
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    isDelayedMessageCompletionRelevantMock.mockResolvedValue(true);
+});
+
+test("runs completion only after an immediate reply is sent and archived", async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const archiveConversation = vi.fn().mockResolvedValue(undefined);
+    const context = {
+        reddit: { modMail: { reply, archiveConversation } },
+    } as unknown as TriggerContext;
+
+    await sendMessageOnDelay(context, {
+        conversationId: "conversation-1",
+        message: "Your appeal was denied.",
+        archive: true,
+        sendAt: new Date(),
+        completionAction,
+    });
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(archiveConversation).toHaveBeenCalledTimes(1);
+    expect(runDelayedMessageCompletionMock).toHaveBeenCalledWith(completionAction, context);
+    const replyOrder = reply.mock.invocationCallOrder[0];
+    const archiveOrder = archiveConversation.mock.invocationCallOrder[0];
+    const completionOrder = runDelayedMessageCompletionMock.mock.invocationCallOrder[0];
+    expect(replyOrder).toBeLessThan(archiveOrder);
+    expect(archiveOrder).toBeLessThan(completionOrder);
+});
+
+test("runs completion after a queued reply is sent and archived", async () => {
+    const queuedMessage = {
+        conversationId: "conversation-1",
+        message: "Your appeal was denied.",
+        archive: true,
+        sendAt: new Date().toISOString(),
+        completionAction,
+    };
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const archiveConversation = vi.fn().mockResolvedValue(undefined);
+    const redis = {
+        exists: vi.fn().mockResolvedValue(false),
+        set: vi.fn().mockResolvedValue(undefined),
+        zRange: vi.fn().mockResolvedValue([{ member: JSON.stringify(queuedMessage), score: Date.now() }]),
+        zRem: vi.fn().mockResolvedValue(undefined),
+        del: vi.fn().mockResolvedValue(undefined),
+    };
+    const context = {
+        reddit: { modMail: { reply, archiveConversation } },
+        redis,
+        scheduler: { runJob: vi.fn() },
+    } as unknown as JobContext;
+
+    await processDelayedMessages({ data: { firstRun: true } } as never, context);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(archiveConversation).toHaveBeenCalledTimes(1);
+    expect(runDelayedMessageCompletionMock).toHaveBeenCalledWith(completionAction, context);
+    expect(redis.zRem).toHaveBeenCalledTimes(1);
+});
+
+test("skips an automatic reply after the appeal has already been handled", async () => {
+    isDelayedMessageCompletionRelevantMock.mockResolvedValue(false);
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const archiveConversation = vi.fn().mockResolvedValue(undefined);
+    const context = {
+        reddit: { modMail: { reply, archiveConversation } },
+    } as unknown as TriggerContext;
+
+    await sendMessageOnDelay(context, {
+        conversationId: "conversation-1",
+        message: "Your appeal was denied.",
+        archive: true,
+        sendAt: new Date(),
+        completionAction,
+    });
+
+    expect(reply).not.toHaveBeenCalled();
+    expect(archiveConversation).not.toHaveBeenCalled();
+    expect(runDelayedMessageCompletionMock).not.toHaveBeenCalled();
+});

--- a/src/modmail/delayedSend.ts
+++ b/src/modmail/delayedSend.ts
@@ -2,28 +2,45 @@ import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext } from "@devv
 import { addMinutes, addSeconds } from "date-fns";
 import json2md from "json2md";
 import { ControlSubredditJob } from "../constants.js";
+import { DelayedMessageCompletionAction, isDelayedMessageCompletionRelevant, runDelayedMessageCompletion } from "./delayedMessageCompletion.js";
 
 interface DelayedMessageOptions {
     conversationId: string;
     message: string;
     sendAt: Date;
     archive?: boolean;
+    completionAction?: DelayedMessageCompletionAction;
 }
 
 const DELAYED_MESSAGE_QUEUE = "delayedMessageQueue";
 
+async function deliverDelayedMessage (
+    params: DelayedMessageOptions,
+    context: TriggerContext | JobContext,
+): Promise<void> {
+    if (params.completionAction && !await isDelayedMessageCompletionRelevant(params.completionAction, context)) {
+        console.log(`Delayed Messages: Skipped obsolete message for conversation ${params.conversationId}`);
+        return;
+    }
+
+    await context.reddit.modMail.reply({
+        conversationId: params.conversationId,
+        isAuthorHidden: true,
+        body: params.message,
+    });
+
+    if (params.archive) {
+        await context.reddit.modMail.archiveConversation(params.conversationId);
+    }
+
+    if (params.completionAction) {
+        await runDelayedMessageCompletion(params.completionAction, context);
+    }
+}
+
 export async function sendMessageOnDelay (context: TriggerContext, params: DelayedMessageOptions) {
     if (params.sendAt <= addSeconds(new Date(), 10)) {
-        await context.reddit.modMail.reply({
-            conversationId: params.conversationId,
-            isAuthorHidden: true,
-            body: params.message,
-        });
-
-        if (params.archive) {
-            await context.reddit.modMail.archiveConversation(params.conversationId);
-        }
-
+        await deliverDelayedMessage(params, context);
         return;
     }
 
@@ -61,15 +78,7 @@ export async function processDelayedMessages (event: ScheduledJobEvent<JSONObjec
     const firstMessage = JSON.parse(queuedMessages[0].member) as DelayedMessageOptions;
     await context.redis.zRem(DELAYED_MESSAGE_QUEUE, [queuedMessages[0].member]);
 
-    await context.reddit.modMail.reply({
-        conversationId: firstMessage.conversationId,
-        isAuthorHidden: true,
-        body: firstMessage.message,
-    });
-
-    if (firstMessage.archive) {
-        await context.reddit.modMail.archiveConversation(firstMessage.conversationId);
-    }
+    await deliverDelayedMessage(firstMessage, context);
 
     if (queuedMessages.length > 1) {
         await context.scheduler.runJob({

--- a/src/statistics/appealOutcomeStatistics.test.ts
+++ b/src/statistics/appealOutcomeStatistics.test.ts
@@ -1,0 +1,111 @@
+import { TriggerContext } from "@devvit/public-api";
+import { AppealTrackedOutcome } from "../modmail/appealOutcomeTracking.js";
+import {
+    formatAppealConfigNameForTable,
+    markTrackedAppealOutcome,
+    parseTrackedAppealOutcomeEvent,
+    summarizeTrackedAppealOutcomeEntries,
+} from "./appealOutcomeStatistics.js";
+
+function eventMetadata (
+    conversationId: string,
+    outcome: AppealTrackedOutcome,
+    configName: string,
+): string {
+    return JSON.stringify({ conversationId, outcome, configName });
+}
+
+test("summarizes one 30-day read into all configured windows", () => {
+    const now = new Date("2026-07-12T12:00:00.000Z");
+    const hour = 60 * 60 * 1000;
+    const day = 24 * hour;
+
+    const summaries = summarizeTrackedAppealOutcomeEntries([
+        {
+            score: now.getTime() - hour,
+            metadata: eventMetadata("conversation-1", AppealTrackedOutcome.AutomaticGrant, "Grant rule"),
+        },
+        {
+            score: now.getTime() - (2 * day),
+            metadata: eventMetadata("conversation-2", AppealTrackedOutcome.AutomaticDenial, "Denial rule"),
+        },
+        {
+            score: now.getTime() - (10 * day),
+            metadata: eventMetadata("conversation-3", AppealTrackedOutcome.AutomaticDenial, "Denial rule"),
+        },
+        {
+            score: now.getTime() - (31 * day),
+            metadata: eventMetadata("conversation-4", AppealTrackedOutcome.AutomaticGrant, "Old grant rule"),
+        },
+    ], now);
+
+    expect(summaries.map(summary => ({
+        label: summary.label,
+        grants: summary.automaticGrants,
+        denials: summary.automaticDenials,
+    }))).toEqual([
+        { label: "Past 24 hours", grants: 1, denials: 0 },
+        { label: "Past 7 days", grants: 1, denials: 1 },
+        { label: "Past 30 days", grants: 1, denials: 2 },
+    ]);
+
+    expect(summaries[2].byConfig["Denial rule"][AppealTrackedOutcome.AutomaticDenial]).toBe(2);
+});
+
+test("ignores malformed or incomplete outcome metadata", () => {
+    const now = new Date("2026-07-12T12:00:00.000Z");
+    const summaries = summarizeTrackedAppealOutcomeEntries([
+        { score: now.getTime(), metadata: "not-json" },
+        { score: now.getTime(), metadata: JSON.stringify({ outcome: AppealTrackedOutcome.AutomaticGrant }) },
+        { score: now.getTime(), metadata: undefined },
+    ], now);
+
+    expect(summaries.every(summary => summary.automaticGrants === 0 && summary.automaticDenials === 0)).toBe(true);
+    expect(parseTrackedAppealOutcomeEvent("not-json")).toBeUndefined();
+});
+
+test("stores at most one event for each conversation and outcome", async () => {
+    const scores = new Map<string, number>();
+    const metadata = new Map<string, string>();
+    const redis = {
+        hSetNX: vi.fn((_key: string, member: string, value: string) => {
+            if (metadata.has(member)) {
+                return false;
+            }
+            metadata.set(member, value);
+            return true;
+        }),
+        hDel: vi.fn((_key: string, members: string[]) => {
+            members.forEach(member => metadata.delete(member));
+        }),
+        zAdd: vi.fn((_key: string, entry: { member: string; score: number }) => {
+            scores.set(entry.member, entry.score);
+        }),
+    };
+    const context = { redis } as unknown as TriggerContext;
+    const now = new Date("2026-07-12T12:00:00.000Z");
+
+    const first = await markTrackedAppealOutcome(
+        AppealTrackedOutcome.AutomaticDenial,
+        "Denial rule",
+        "conversation-1",
+        context,
+        now,
+    );
+    const second = await markTrackedAppealOutcome(
+        AppealTrackedOutcome.AutomaticDenial,
+        "Denial rule",
+        "conversation-1",
+        context,
+        new Date(now.getTime() + 1000),
+    );
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(redis.zAdd).toHaveBeenCalledTimes(1);
+    expect(metadata.size).toBe(1);
+});
+
+test("sanitizes appeal config names for Reddit markdown tables", () => {
+    expect(formatAppealConfigNameForTable("First | rule\nsecond line")).toBe("First ¦ rule second line");
+});

--- a/src/statistics/appealOutcomeStatistics.ts
+++ b/src/statistics/appealOutcomeStatistics.ts
@@ -1,0 +1,253 @@
+import { JobContext, TriggerContext } from "@devvit/public-api";
+import { subDays, subHours } from "date-fns";
+import json2md from "json2md";
+import { AppealTrackedOutcome } from "../modmail/appealOutcomeTracking.js";
+
+const TRACKED_APPEAL_OUTCOME_STATISTICS_KEY = "trackedAppealOutcomeStatistics";
+const TRACKED_APPEAL_OUTCOME_METADATA_KEY = "trackedAppealOutcomeMetadata";
+const TRACKED_APPEAL_OUTCOME_RETENTION_DAYS = 31;
+
+export interface TrackedAppealOutcomeEvent {
+    conversationId: string;
+    outcome: AppealTrackedOutcome;
+    configName: string;
+}
+
+interface TrackedAppealOutcomeWindow {
+    label: string;
+    since: Date;
+}
+
+export interface TrackedAppealOutcomeSummary {
+    label: string;
+    automaticGrants: number;
+    automaticDenials: number;
+    byConfig: Record<string, Record<AppealTrackedOutcome, number>>;
+}
+
+export interface StoredTrackedAppealOutcomeEntry {
+    score: number;
+    metadata: string | undefined;
+}
+
+function getTrackedAppealOutcomeMember (conversationId: string, outcome: AppealTrackedOutcome): string {
+    return `${conversationId}:${outcome}`;
+}
+
+export async function markTrackedAppealOutcome (
+    outcome: AppealTrackedOutcome,
+    configName: string,
+    conversationId: string,
+    context: TriggerContext | JobContext,
+    now = new Date(),
+): Promise<boolean> {
+    const member = getTrackedAppealOutcomeMember(conversationId, outcome);
+    const event: TrackedAppealOutcomeEvent = {
+        conversationId,
+        outcome,
+        configName,
+    };
+    const stored = await context.redis.hSetNX(
+        TRACKED_APPEAL_OUTCOME_METADATA_KEY,
+        member,
+        JSON.stringify(event),
+    );
+    if (!stored) {
+        return false;
+    }
+
+    try {
+        await context.redis.zAdd(TRACKED_APPEAL_OUTCOME_STATISTICS_KEY, {
+            member,
+            score: now.getTime(),
+        });
+    } catch (error) {
+        await context.redis.hDel(TRACKED_APPEAL_OUTCOME_METADATA_KEY, [member]);
+        throw error;
+    }
+
+    return true;
+}
+
+export async function cleanupTrackedAppealOutcomeStatistics (
+    context: JobContext,
+    now = new Date(),
+): Promise<void> {
+    const cutoff = subDays(now, TRACKED_APPEAL_OUTCOME_RETENTION_DAYS).getTime();
+    const expiredEntries = await context.redis.zRange(
+        TRACKED_APPEAL_OUTCOME_STATISTICS_KEY,
+        0,
+        cutoff,
+        { by: "score" },
+    );
+
+    if (expiredEntries.length === 0) {
+        return;
+    }
+
+    await context.redis.zRemRangeByScore(TRACKED_APPEAL_OUTCOME_STATISTICS_KEY, 0, cutoff);
+    await context.redis.hDel(
+        TRACKED_APPEAL_OUTCOME_METADATA_KEY,
+        expiredEntries.map(entry => entry.member),
+    );
+}
+
+export function parseTrackedAppealOutcomeEvent (metadata: string | undefined): TrackedAppealOutcomeEvent | undefined {
+    if (!metadata) {
+        return;
+    }
+
+    try {
+        const parsed = JSON.parse(metadata) as Partial<TrackedAppealOutcomeEvent>;
+        if (
+            !parsed.conversationId
+            || !parsed.configName
+            || !parsed.outcome
+            || !Object.values(AppealTrackedOutcome).includes(parsed.outcome)
+        ) {
+            return;
+        }
+
+        return {
+            conversationId: parsed.conversationId,
+            outcome: parsed.outcome,
+            configName: parsed.configName,
+        };
+    } catch {
+        return;
+    }
+}
+
+export function summarizeTrackedAppealOutcomeEntries (
+    entries: StoredTrackedAppealOutcomeEntry[],
+    now = new Date(),
+): TrackedAppealOutcomeSummary[] {
+    const windows: TrackedAppealOutcomeWindow[] = [
+        { label: "Past 24 hours", since: subHours(now, 24) },
+        { label: "Past 7 days", since: subDays(now, 7) },
+        { label: "Past 30 days", since: subDays(now, 30) },
+    ];
+
+    const summaries: TrackedAppealOutcomeSummary[] = windows.map(window => ({
+        label: window.label,
+        automaticGrants: 0,
+        automaticDenials: 0,
+        byConfig: {},
+    }));
+
+    for (const entry of entries) {
+        const event = parseTrackedAppealOutcomeEvent(entry.metadata);
+        if (!event) {
+            continue;
+        }
+
+        for (let i = 0; i < windows.length; i++) {
+            if (entry.score < windows[i].since.getTime() || entry.score > now.getTime()) {
+                continue;
+            }
+
+            const summary = summaries[i];
+            if (event.outcome === AppealTrackedOutcome.AutomaticGrant) {
+                summary.automaticGrants++;
+            } else {
+                summary.automaticDenials++;
+            }
+
+            summary.byConfig[event.configName] ??= {
+                [AppealTrackedOutcome.AutomaticGrant]: 0,
+                [AppealTrackedOutcome.AutomaticDenial]: 0,
+            };
+            summary.byConfig[event.configName][event.outcome]++;
+        }
+    }
+
+    return summaries;
+}
+
+export async function getTrackedAppealOutcomeSummaries (
+    context: JobContext,
+    now = new Date(),
+): Promise<TrackedAppealOutcomeSummary[]> {
+    const entries = await context.redis.zRange(
+        TRACKED_APPEAL_OUTCOME_STATISTICS_KEY,
+        subDays(now, 30).getTime(),
+        now.getTime(),
+        { by: "score" },
+    );
+    const metadata = await context.redis.hMGet(
+        TRACKED_APPEAL_OUTCOME_METADATA_KEY,
+        entries.map(entry => entry.member),
+    );
+
+    return summarizeTrackedAppealOutcomeEntries(
+        entries.map((entry, index) => ({
+            score: entry.score,
+            metadata: metadata[index] ?? undefined,
+        })),
+        now,
+    );
+}
+
+export function formatAppealConfigNameForTable (configName: string): string {
+    return configName.replaceAll("|", "¦").replace(/\r?\n/g, " ");
+}
+
+function formatOutcome (outcome: AppealTrackedOutcome): string {
+    switch (outcome) {
+        case AppealTrackedOutcome.AutomaticGrant:
+            return "Automatic grant";
+        case AppealTrackedOutcome.AutomaticDenial:
+            return "Automatic denial";
+    }
+}
+
+export async function pushTrackedAppealOutcomeStatistics (
+    wikiContent: json2md.DataObject[],
+    context: JobContext,
+): Promise<void> {
+    const now = new Date();
+    await cleanupTrackedAppealOutcomeStatistics(context, now);
+    const summaries = await getTrackedAppealOutcomeSummaries(context, now);
+
+    wikiContent.push({ h2: "Automatically resolved appeal outcomes" });
+    wikiContent.push({
+        p: "These statistics count tracked appeal configs only after the public reply is sent, the conversation is archived, and the active appeal marker is cleared.",
+    });
+
+    wikiContent.push({
+        table: {
+            headers: ["Window", "Automatic grants", "Automatic denials", "Total automatically resolved"],
+            rows: summaries.map(summary => [
+                summary.label,
+                summary.automaticGrants.toLocaleString(),
+                summary.automaticDenials.toLocaleString(),
+                (summary.automaticGrants + summary.automaticDenials).toLocaleString(),
+            ]),
+        },
+    });
+
+    const configRows = summaries.flatMap(summary => Object.entries(summary.byConfig).flatMap(([configName, outcomeCounts]) => [
+        [
+            summary.label,
+            formatOutcome(AppealTrackedOutcome.AutomaticGrant),
+            formatAppealConfigNameForTable(configName),
+            outcomeCounts[AppealTrackedOutcome.AutomaticGrant].toLocaleString(),
+        ],
+        [
+            summary.label,
+            formatOutcome(AppealTrackedOutcome.AutomaticDenial),
+            formatAppealConfigNameForTable(configName),
+            outcomeCounts[AppealTrackedOutcome.AutomaticDenial].toLocaleString(),
+        ],
+    ])).filter(([, , , count]) => count !== "0");
+
+    if (configRows.length > 0) {
+        wikiContent.push({ h3: "Automatically resolved outcomes by appeal config" });
+        wikiContent.push({
+            table: {
+                headers: ["Window", "Outcome", "Appeal config", "Count"],
+                rows: configRows,
+            },
+        });
+    }
+}

--- a/src/statistics/appealStatistics.ts
+++ b/src/statistics/appealStatistics.ts
@@ -3,6 +3,7 @@ import { addHours, eachDayOfInterval, format, startOfDay, subDays } from "date-f
 import { deleteKeyForAppeal, isActiveAppeal } from "../modmail/controlSubModmail.js";
 import json2md from "json2md";
 import { ModmailMessage } from "../modmail/modmail.js";
+import { pushTrackedAppealOutcomeStatistics } from "./appealOutcomeStatistics.js";
 
 function getKeyForDate (date = new Date()): string {
     return `appealStatistics~${format(date, "yyyy-MM-dd")}`;
@@ -50,7 +51,6 @@ export async function updateAppealStatistics (context: JobContext) {
 
     if (Object.keys(appealData).length === 0) {
         console.log("No appeal data found for the last week.");
-        return;
     }
 
     const wikiContent: json2md.DataObject[] = [
@@ -61,7 +61,11 @@ export async function updateAppealStatistics (context: JobContext) {
     const headers = ["Username", "Appeals"];
     const rows = Object.entries(appealData).map(([username, count]) => [`/u/${username}`, count.toLocaleString()]);
 
-    wikiContent.push({ table: { headers, rows } });
+    if (rows.length === 0) {
+        wikiContent.push({ p: "No appeals were manually handled within the last week." });
+    } else {
+        wikiContent.push({ table: { headers, rows } });
+    }
 
     wikiContent.push({ h2: "Yesterday's activity (UTC)" });
 
@@ -84,6 +88,8 @@ export async function updateAppealStatistics (context: JobContext) {
         const todayRows = todayData.map(({ member, score }) => [`/u/${member}`, score.toLocaleString()]);
         wikiContent.push({ table: { headers: todayHeaders, rows: todayRows } });
     }
+
+    await pushTrackedAppealOutcomeStatistics(wikiContent, context);
 
     wikiContent.push({ p: "This page updates every hour, and may update more frequently." });
 


### PR DESCRIPTION
## Summary

Adds explicit tracking for appeal config entries that conclusively resolve appeals automatically.

## Changes

- Adds `trackOutcome: automaticGrant` and `trackOutcome: automaticDenial` as optional appeal config properties.
- Validates that automatic grants use a grant-producing `setStatus`.
- Validates that automatic denials include both a public reply and `archive: true`.
- Records outcomes only after the corresponding moderation actions succeed.
- Prevents duplicate statistics for the same conversation and outcome.
- Cancels delayed automated resolutions when a moderator has already handled the appeal.
- Removes automatically resolved appeals from the active-appeal workload.
- Reports resolved automated outcomes for the past 24 hours, 7 days, and 30 days.
- Includes per-config outcome totals.

## Rationale

These statistics measure appeals that are actually resolved without moderator intervention, rather than merely counting automated messages. This provides a more defensible estimate of how much the automated appeal configuration reduces moderator workload.

## Tests

- `npx.cmd tsc --build`
- `npx.cmd tsc --build --clean`
- `npm.cmd run test:unit`
- `npx.cmd eslint`