### PR TITLE
Add modmail JSON account review scheduling

### DIFF
--- a/src/modmail/accountReview.ts
+++ b/src/modmail/accountReview.ts
@@ -1,6 +1,8 @@
 import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext } from "@devvit/public-api";
 import json2md from "json2md";
 import { getUsernameFromUrl, getUserOrUndefined } from "../utility.js";
+import { getUserStatus } from "../dataStore.js";
+import { isLinkId } from "@devvit/public-api/types/tid.js";
 import pluralize from "pluralize";
 import { addDays, addSeconds } from "date-fns";
 import { CONTROL_SUBREDDIT, ControlSubredditJob } from "../constants.js";
@@ -18,6 +20,12 @@ interface AccountReviewData {
     reviewReason?: string;
 }
 
+export enum AccountReviewScheduleResult {
+    Scheduled = "scheduled",
+    UserNotFound = "userNotFound",
+    MissingTrackingPost = "missingTrackingPost",
+}
+
 export async function submitAccountForReview (postId: string, requestedBy: string, duration: number, reason: string | undefined, context: TriggerContext) {
     if (context.subredditName !== CONTROL_SUBREDDIT) {
         throw new Error("Account reviews can only be submitted from the control subreddit.");
@@ -32,6 +40,38 @@ export async function submitAccountForReview (postId: string, requestedBy: strin
     await context.redis.set(accountReviewKey(postId), JSON.stringify(reviewData), { expiration: addDays(new Date(), duration + 1) });
     await context.redis.zAdd(ACCOUNT_REVIEW_QUEUE, { member: postId, score: addDays(new Date(), duration).getTime() });
     console.log(`Account Review: Submitted post ${postId} for review by ${requestedBy} in ${duration} ${pluralize("day", duration)}.`);
+}
+
+export async function submitAccountForReviewByUsername (
+    username: string,
+    requestedBy: string,
+    duration: number,
+    reason: string | undefined,
+    context: TriggerContext,
+): Promise<AccountReviewScheduleResult> {
+    if (context.subredditName !== CONTROL_SUBREDDIT) {
+        throw new Error("Account reviews can only be submitted from the control subreddit.");
+    }
+
+    const currentStatus = await getUserStatus(username, context);
+    if (!currentStatus) {
+        return AccountReviewScheduleResult.UserNotFound;
+    }
+
+    const trackingPostId = currentStatus.trackingPostId;
+    if (typeof trackingPostId !== "string" || !isLinkId(trackingPostId)) {
+        return AccountReviewScheduleResult.MissingTrackingPost;
+    }
+
+    await submitAccountForReview(
+        trackingPostId,
+        requestedBy,
+        duration,
+        reason,
+        context,
+    );
+
+    return AccountReviewScheduleResult.Scheduled;
 }
 
 export async function checkAccountsForReview (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {

--- a/src/modmail/bulkSubmission.test.ts
+++ b/src/modmail/bulkSubmission.test.ts
@@ -1,0 +1,66 @@
+import { AccountReviewScheduleResult } from "./accountReview.js";
+import { buildScheduleReviewReply } from "./bulkSubmission.js";
+
+test("buildScheduleReviewReply reports scheduled reviews with correct grammar", () => {
+    expect(buildScheduleReviewReply([
+        {
+            username: "ExampleUser",
+            result: AccountReviewScheduleResult.Scheduled,
+        },
+    ], 2)).toEqual([
+        {
+            p: "Scheduled 1 account review in 2 days.",
+        },
+    ]);
+});
+
+test("buildScheduleReviewReply explains skipped accounts", () => {
+    expect(buildScheduleReviewReply([
+        {
+            username: "ScheduledUser",
+            result: AccountReviewScheduleResult.Scheduled,
+        },
+        {
+            username: "UnknownUser",
+            result: AccountReviewScheduleResult.UserNotFound,
+        },
+        {
+            username: "MissingPost",
+            result: AccountReviewScheduleResult.MissingTrackingPost,
+        },
+    ], 1)).toEqual([
+        {
+            p: "Scheduled 1 account review in 1 day.",
+        },
+        {
+            p: "Skipped 2 accounts:",
+        },
+        {
+            ul: [
+                "/u/UnknownUser: no existing Bot Bouncer status was found",
+                "/u/MissingPost: no tracking post was available",
+            ],
+        },
+    ]);
+});
+
+test("buildScheduleReviewReply handles a request with no schedulable accounts", () => {
+    expect(buildScheduleReviewReply([
+        {
+            username: "UnknownUser",
+            result: AccountReviewScheduleResult.UserNotFound,
+        },
+    ], 7)).toEqual([
+        {
+            p: "Scheduled 0 account reviews in 7 days.",
+        },
+        {
+            p: "Skipped 1 account:",
+        },
+        {
+            ul: [
+                "/u/UnknownUser: no existing Bot Bouncer status was found",
+            ],
+        },
+    ]);
+});

--- a/src/modmail/bulkSubmission.ts
+++ b/src/modmail/bulkSubmission.ts
@@ -9,6 +9,7 @@ import pluralize from "pluralize";
 import { ModmailMessage } from "./modmail.js";
 import { getControlSubSettings } from "../settings.js";
 import markdownEscape from "markdown-escape";
+import { AccountReviewScheduleResult, submitAccountForReviewByUsername } from "./accountReview.js";
 
 interface UserWithDetails {
     username: string;
@@ -16,10 +17,18 @@ interface UserWithDetails {
     reason?: string;
 }
 
+interface ScheduleReviewSubmission {
+    usernames: string[];
+    days: number;
+    reason?: string;
+}
+
 interface BulkSubmission {
     usernames?: string[];
     userDetails?: UserWithDetails[];
     reason?: string;
+
+    schedule_review?: ScheduleReviewSubmission;
 }
 
 const schema: JSONSchemaType<BulkSubmission> = {
@@ -50,6 +59,31 @@ const schema: JSONSchemaType<BulkSubmission> = {
             type: "string",
             nullable: true,
         },
+        // eslint-disable-next-line camelcase
+        schedule_review: {
+            type: "object",
+            properties: {
+                usernames: {
+                    type: "array",
+                    items: {
+                        type: "string",
+                        minLength: 1,
+                    },
+                    minItems: 1,
+                },
+                days: {
+                    type: "integer",
+                    minimum: 1,
+                },
+                reason: {
+                    type: "string",
+                    nullable: true,
+                },
+            },
+            required: ["usernames", "days"],
+            additionalProperties: false,
+            nullable: true,
+        },
     },
     additionalProperties: false,
 };
@@ -59,6 +93,102 @@ interface BulkItem {
     initialStatus: UserStatus;
     submitter: string;
     reason?: string;
+}
+
+export interface ScheduleReviewResult {
+    username: string;
+    result: AccountReviewScheduleResult;
+}
+
+function describeScheduleReviewResult (result: AccountReviewScheduleResult): string {
+    switch (result) {
+        case AccountReviewScheduleResult.UserNotFound:
+            return "no existing Bot Bouncer status was found";
+        case AccountReviewScheduleResult.MissingTrackingPost:
+            return "no tracking post was available";
+        case AccountReviewScheduleResult.Scheduled:
+            return "scheduled";
+        default:
+            throw new Error(`Unknown account-review scheduling result: ${result as string}`);
+    }
+}
+
+export function buildScheduleReviewReply (
+    results: ScheduleReviewResult[],
+    days: number,
+): json2md.DataObject[] {
+    const scheduled = results.filter(item => item.result === AccountReviewScheduleResult.Scheduled);
+    const skipped = results.filter(item => item.result !== AccountReviewScheduleResult.Scheduled);
+
+    const reply: json2md.DataObject[] = [{
+        p: `Scheduled ${scheduled.length} ${pluralize("account review", scheduled.length)} in ${days} ${pluralize("day", days)}.`,
+    }];
+
+    if (skipped.length > 0) {
+        reply.push({
+            p: `Skipped ${skipped.length} ${pluralize("account", skipped.length)}:`,
+        });
+        reply.push({
+            ul: skipped.map(item => `/u/${markdownEscape(item.username)}: ${describeScheduleReviewResult(item.result)}`),
+        });
+    }
+
+    return reply;
+}
+
+async function handleScheduleReviewSubmission (
+    submitter: string,
+    trusted: boolean,
+    conversationId: string,
+    scheduleReview: ScheduleReviewSubmission,
+    context: TriggerContext,
+): Promise<boolean> {
+    if (!trusted) {
+        console.log(`Schedule review: Rejected request from ${submitter} because they are not a trusted submitter.`);
+
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: json2md([{
+                p: "Only trusted submitters can schedule account reviews.",
+            }]),
+            isAuthorHidden: false,
+        });
+
+        await context.reddit.modMail.archiveConversation(conversationId);
+        return false;
+    }
+
+    const usernames = [...new Map(scheduleReview.usernames.map(username => [
+        username.toLowerCase(),
+        username,
+    ])).values()];
+
+    const results: ScheduleReviewResult[] = await Promise.all(usernames.map(async username => ({
+        username,
+        result: await submitAccountForReviewByUsername(
+            username,
+            submitter,
+            scheduleReview.days,
+            scheduleReview.reason,
+            context,
+        ),
+    })));
+
+    await context.reddit.modMail.reply({
+        conversationId,
+        body: json2md(buildScheduleReviewReply(results, scheduleReview.days)),
+        isAuthorHidden: false,
+    });
+
+    await context.reddit.modMail.archiveConversation(conversationId);
+
+    const scheduledCount = results.filter(item => item.result === AccountReviewScheduleResult.Scheduled).length;
+
+    if (scheduledCount > 0) {
+        console.log(`Schedule review: Scheduled ${scheduledCount} ${pluralize("account review", scheduledCount)} from ${submitter}.`);
+    }
+
+    return scheduledCount > 0;
 }
 
 async function handleBulkItems (items: BulkItem[], context: TriggerContext): Promise<number> {
@@ -111,18 +241,6 @@ async function handleBulkItems (items: BulkItem[], context: TriggerContext): Pro
 }
 
 export async function handleBulkSubmission (submitter: string, trusted: boolean, conversationId: string, message: string, context: TriggerContext): Promise<boolean> {
-    const controlSubSettings = await getControlSubSettings(context);
-    if (!controlSubSettings.allowNewSubmissions) {
-        console.log(`Bulk submission: New submission from ${submitter} was rejected as new submissions are not currently allowed.`);
-        await context.reddit.modMail.reply({
-            conversationId,
-            body: json2md([{ p: "Bot Bouncer is not currently accepting new submissions." }]),
-            isAuthorHidden: false,
-        });
-        await context.reddit.modMail.archiveConversation(conversationId);
-        return false;
-    }
-
     console.log(`Bulk submission: New submission from ${submitter}`);
     let data: BulkSubmission;
     try {
@@ -156,6 +274,33 @@ export async function handleBulkSubmission (submitter: string, trusted: boolean,
             ]),
             isAuthorHidden: false,
         });
+        await context.reddit.modMail.archiveConversation(conversationId);
+        return false;
+    }
+
+    const scheduleReview = data.schedule_review;
+    if (scheduleReview) {
+        return await handleScheduleReviewSubmission(
+            submitter,
+            trusted,
+            conversationId,
+            scheduleReview,
+            context,
+        );
+    }
+
+    const controlSubSettings = await getControlSubSettings(context);
+    if (!controlSubSettings.allowNewSubmissions) {
+        console.log(`Bulk submission: New submission from ${submitter} was rejected as new submissions are not currently allowed.`);
+
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: json2md([{
+                p: "Bot Bouncer is not currently accepting new submissions.",
+            }]),
+            isAuthorHidden: false,
+        });
+
         await context.reddit.modMail.archiveConversation(conversationId);
         return false;
     }


### PR DESCRIPTION
## Summary

Adds trusted-submitter support for scheduling account reviews through JSON modmail.

## Changes

- Adds the `schedule_review` JSON object with `usernames`, `days`, and an optional `reason`.
- Restricts account-review scheduling to trusted submitters.
- Resolves each username to its existing Bot Bouncer tracking post.
- Reuses the existing account-review queue and reminder workflow.
- Deduplicates repeated usernames case-insensitively within one request.
- Reports how many reviews were scheduled.
- Lists accounts skipped because no Bot Bouncer status or tracking post was available.
- Preserves ordinary bulk-submission behavior and the new-submission availability setting.
- Preserves the existing account-reminder enablement safeguard.

## Example

```json
{
  "schedule_review": {
    "usernames": ["foo", "bar", "foobar"],
    "days": 2,
    "reason": "Optional reason added here"
  }
}
```

## Validation

```powershell
npm.cmd exec -- tsc --noEmit
npm.cmd exec -- eslint .
npm.cmd exec -- vitest run src/modmail/bulkSubmission.test.ts
npm.cmd test
git diff --check
```

Closes #364
