### PR TITLE
Read config edit reasons from wiki revisions

### DIFF
--- a/src/userEvaluation/configEditSummaries.test.ts
+++ b/src/userEvaluation/configEditSummaries.test.ts
@@ -1,4 +1,4 @@
-import { buildEvaluatorConfigEditSummaryWikiPage, nextTopOfHour, summarizeEvaluatorConfigChanges } from "./configEditSummaries.js";
+import { buildEvaluatorConfigEditSummaryWikiPage, findMatchingRevisionReason, nextTopOfHour, normalizeWikiTimestamp, summarizeEvaluatorConfigChanges } from "./configEditSummaries.js";
 
 test("summarizeEvaluatorConfigChanges counts array additions and removals by evaluator module", () => {
     const previousVariables = {
@@ -82,4 +82,90 @@ test("nextTopOfHour returns the next exact hour", () => {
     const actual = nextTopOfHour(new Date(Date.UTC(2026, 5, 20, 14, 7, 35)));
 
     expect(actual.toISOString()).toBe("2026-06-20T15:00:00.000Z");
+});
+test("normalizeWikiTimestamp converts Reddit timestamps expressed in seconds", () => {
+    const expected = Date.UTC(2026, 6, 10, 18, 30);
+    const timestampInSeconds = expected / 1000;
+
+    expect(normalizeWikiTimestamp(timestampInSeconds)).toBe(expected);
+});
+
+test("normalizeWikiTimestamp preserves timestamps already expressed in milliseconds", () => {
+    const timestampInMilliseconds = Date.UTC(2026, 6, 10, 18, 30);
+
+    expect(normalizeWikiTimestamp(timestampInMilliseconds)).toBe(timestampInMilliseconds);
+});
+
+test("findMatchingRevisionReason selects the nearest revision by the same moderator", () => {
+    const updatedAt = Date.UTC(2026, 6, 10, 18, 30);
+
+    const revisions = [
+        {
+            timestamp: updatedAt + 4 * 60 * 1000,
+            updatedBy: "CR29-22-2805",
+            reason: "Later matching revision.",
+        },
+        {
+            timestamp: updatedAt + 60 * 1000,
+            updatedBy: "CR29-22-2805",
+            reason: "Nearest matching revision.",
+        },
+        {
+            timestamp: updatedAt,
+            updatedBy: "different-moderator",
+            reason: "Wrong moderator.",
+        },
+    ];
+
+    expect(
+        findMatchingRevisionReason(
+            revisions,
+            "CR29-22-2805",
+            updatedAt,
+        ),
+    ).toBe("Nearest matching revision.");
+});
+
+test("findMatchingRevisionReason rejects revisions outside the lookup window", () => {
+    const updatedAt = Date.UTC(2026, 6, 10, 18, 30);
+
+    const revisions = [
+        {
+            timestamp: updatedAt + 6 * 60 * 1000,
+            updatedBy: "CR29-22-2805",
+            reason: "Outside the lookup window.",
+        },
+    ];
+
+    expect(
+        findMatchingRevisionReason(
+            revisions,
+            "CR29-22-2805",
+            updatedAt,
+        ),
+    ).toBeUndefined();
+});
+
+test("findMatchingRevisionReason ignores revisions without a usable reason", () => {
+    const updatedAt = Date.UTC(2026, 6, 10, 18, 30);
+
+    const revisions = [
+        {
+            timestamp: updatedAt,
+            updatedBy: "CR29-22-2805",
+        },
+        {
+            timestamp: updatedAt + 60 * 1000,
+            updatedBy: "CR29-22-2805",
+            reason: "Usable revision reason.",
+        },
+    ];
+
+    expect(
+        findMatchingRevisionReason(
+            revisions,
+            "CR29-22-2805",
+            updatedAt,
+        ),
+    ).toBe("Usable revision reason.");
 });

--- a/src/userEvaluation/configEditSummaries.ts
+++ b/src/userEvaluation/configEditSummaries.ts
@@ -6,9 +6,11 @@ import pluralize from "pluralize";
 
 const CONFIG_EDIT_SUMMARIES_KEY = "evaluatorConfigEditSummaries";
 const CONFIG_EDIT_SUMMARY_JOB_QUEUED_KEY = "evaluatorConfigEditSummaryJobQueued";
+const EVALUATOR_CONFIG_WIKI_PAGE = "evaluator-config";
 const CONFIG_EDIT_SUMMARY_WIKI_PAGE = "evaluator-config-summaries";
 const CONFIG_EDIT_SUMMARY_RETENTION_DAYS = 14;
 const REVISION_GROUP_INACTIVITY_THRESHOLD_MS = 20 * 60 * 1000;
+const REVISION_REASON_LOOKUP_WINDOW_MS = 5 * 60 * 1000;
 
 interface ModuleChangeSummary {
     added: number;
@@ -28,6 +30,24 @@ interface RecordEvaluatorConfigEditSummaryOptions {
     updatedBy: string;
     updatedAt?: number;
     revisionReason?: string;
+}
+
+interface WikiRevisionSummary {
+    timestamp: number;
+    updatedBy: string;
+    reason?: string;
+}
+
+const EARLIEST_VALID_REDDIT_TIMESTAMP_MS = Date.UTC(2005, 0, 1);
+
+export function normalizeWikiTimestamp (input: Date | number): number {
+    const timestamp = input instanceof Date ? input.getTime() : input;
+
+    if (timestamp > 0 && timestamp < EARLIEST_VALID_REDDIT_TIMESTAMP_MS) {
+        return timestamp * 1000;
+    }
+
+    return timestamp;
 }
 
 function parseStoredVariables (variables: Record<string, string>): Record<string, unknown> {
@@ -140,6 +160,73 @@ function sanitizeInlineText (input: string): string {
     return input.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
 }
 
+function normalizeRevisionReason (input: string | undefined): string | undefined {
+    const reason = sanitizeInlineText(input ?? "");
+    if (reason.length === 0 || reason.toLowerCase() === "no revision reason provided.") {
+        return;
+    }
+
+    return reason;
+}
+
+async function loadEvaluatorConfigWikiRevisions (context: JobContext): Promise<WikiRevisionSummary[]> {
+    try {
+        const revisions = await context.reddit.getWikiPageRevisions({
+            subredditName: CONTROL_SUBREDDIT,
+            page: EVALUATOR_CONFIG_WIKI_PAGE,
+            limit: 100,
+        }).all();
+
+        return revisions
+            .map(revision => ({
+                timestamp: normalizeWikiTimestamp(revision.date),
+                updatedBy: revision.author.username,
+                reason: normalizeRevisionReason(revision.reason),
+            }))
+            .sort((a, b) => b.timestamp - a.timestamp);
+    } catch (error) {
+        console.error("Evaluator Config Edit Summaries: Failed to load evaluator-config wiki revisions.", error);
+        return [];
+    }
+}
+
+export function findMatchingRevisionReason (revisions: WikiRevisionSummary[], updatedBy: string, updatedAt?: number): string | undefined {
+    const matchingModeratorRevisions = revisions.filter(revision => revision.updatedBy === updatedBy && revision.reason);
+    if (matchingModeratorRevisions.length === 0) {
+        return;
+    }
+
+    if (updatedAt === undefined) {
+        return matchingModeratorRevisions[0].reason;
+    }
+
+    return matchingModeratorRevisions
+        .filter(revision => Math.abs(revision.timestamp - updatedAt) <= REVISION_REASON_LOOKUP_WINDOW_MS)
+        .sort((a, b) => Math.abs(a.timestamp - updatedAt) - Math.abs(b.timestamp - updatedAt))[0]
+        ?.reason;
+}
+
+async function resolveEvaluatorConfigRevisionReason (context: JobContext, updatedBy: string, updatedAt?: number): Promise<string | undefined> {
+    const revisions = await loadEvaluatorConfigWikiRevisions(context);
+    return findMatchingRevisionReason(revisions, updatedBy, updatedAt);
+}
+
+async function hydrateMissingRevisionReasons (summaries: EvaluatorConfigEditSummary[], context: JobContext): Promise<EvaluatorConfigEditSummary[]> {
+    if (summaries.every(summary => normalizeRevisionReason(summary.revisionReason))) {
+        return summaries;
+    }
+
+    const revisions = await loadEvaluatorConfigWikiRevisions(context);
+    return summaries.map((summary) => {
+        if (normalizeRevisionReason(summary.revisionReason)) {
+            return summary;
+        }
+
+        const revisionReason = findMatchingRevisionReason(revisions, summary.updatedBy, summary.timestamp);
+        return revisionReason ? { ...summary, revisionReason } : summary;
+    });
+}
+
 function formatUtcTimestamp (timestamp: number): string {
     return new Date(timestamp).toISOString().substring(0, 16).replace("T", " ") + " UTC";
 }
@@ -192,7 +279,7 @@ function formatSummaryLine (summary: EvaluatorConfigEditSummary): string {
         .filter((value): value is string => Boolean(value))
         .join("; ");
 
-    const revisionReason = sanitizeInlineText(summary.revisionReason ?? "No revision reason provided.");
+    const revisionReason = normalizeRevisionReason(summary.revisionReason) ?? "No revision reason provided.";
     const changeText = changes.length > 0 ? changes : "no countable variable changes";
 
     return `* **${formatUtcTimestamp(summary.timestamp)}**; applied by **${sanitizeInlineText(summary.updatedBy)}**; ${changeText}. Revision reason: ${ensureSentenceEnd(revisionReason)}`;
@@ -313,12 +400,15 @@ export async function recordEvaluatorConfigEditSummary (options: RecordEvaluator
     }
 
     const now = new Date();
+    const timestamp = options.updatedAt ?? now.getTime();
+    const revisionReason = normalizeRevisionReason(options.revisionReason)
+        ?? await resolveEvaluatorConfigRevisionReason(context, options.updatedBy, timestamp);
     const summaries = await loadSummaries(context);
     summaries.push({
-        timestamp: options.updatedAt ?? now.getTime(),
+        timestamp,
         updatedBy: options.updatedBy,
         changes,
-        revisionReason: options.revisionReason,
+        revisionReason,
     });
 
     await saveSummaries(summaries, context, now);
@@ -331,7 +421,7 @@ export async function updateEvaluatorConfigEditSummaryPage (_: unknown, context:
     }
 
     const now = new Date();
-    const summaries = await loadSummaries(context);
+    const summaries = await hydrateMissingRevisionReasons(await loadSummaries(context), context);
     await saveSummaries(summaries, context, now);
 
     const retainedSummaries = summaries.filter(summary => summary.timestamp >= subDays(now, CONFIG_EDIT_SUMMARY_RETENTION_DAYS).getTime());


### PR DESCRIPTION
## Summary

Uses evaluator-config wiki revision history to recover human-written revision reasons for the evaluator-config summary page.

## Changes

- Loads recent revisions from the `evaluator-config` wiki page.
- Normalizes Reddit revision timestamps supplied in seconds or milliseconds.
- Matches a revision reason by moderator and the nearest timestamp within five minutes.
- Ignores empty and default placeholder revision reasons.
- Uses the matched reason when recording a new config-edit summary.
- Hydrates previously stored summaries that are missing revision reasons.
- Preserves the existing revision grouping and variable-change counts.

## Validation

```powershell
npm.cmd exec -- tsc --noEmit
npm.cmd exec -- eslint .
npm.cmd exec -- vitest run src/userEvaluation/configEditSummaries.test.ts
npm.cmd test
git diff --check
```
