### PR TITLE
Add emergency config cleanup workflow

### DIFF
--- a/src/configRevisionReceipts.test.ts
+++ b/src/configRevisionReceipts.test.ts
@@ -1,0 +1,31 @@
+import { getChangedVariableKeys } from "./configRevisionReceipts.js";
+
+test("getChangedVariableKeys reports added, changed, and removed variables", () => {
+    const existingVariables = {
+        "biotext:unchanged": JSON.stringify(["same"]),
+        "definedhandles:changed": JSON.stringify(["old"]),
+        "sociallinks:removed": JSON.stringify(["removed"]),
+    };
+
+    const nextVariables = {
+        "biotext:unchanged": JSON.stringify(["same"]),
+        "definedhandles:changed": JSON.stringify(["new"]),
+        "badusername:added": JSON.stringify(["added"]),
+    };
+
+    const result = getChangedVariableKeys(existingVariables, nextVariables);
+
+    expect(result).toEqual([
+        "badusername:added",
+        "definedhandles:changed",
+        "sociallinks:removed",
+    ]);
+});
+
+test("getChangedVariableKeys returns no keys when variables are unchanged", () => {
+    const variables = {
+        "biotext:example": JSON.stringify(["same"]),
+    };
+
+    expect(getChangedVariableKeys(variables, { ...variables })).toEqual([]);
+});

--- a/src/configRevisionReceipts.ts
+++ b/src/configRevisionReceipts.ts
@@ -1,0 +1,193 @@
+import { Context, JobContext, TriggerContext } from "@devvit/public-api";
+import { addHours, addMinutes, subMinutes } from "date-fns";
+import _ from "lodash";
+import { ALL_RELEVANT_EVALUTORS, CONTROL_SUBREDDIT } from "./constants.js";
+
+const CONFIG_REVISION_RECEIPTS_KEY = "configRevisionReceipts";
+const CONFIG_REVISION_RECENT_KEY = "configRevisionRecent";
+const CONFIG_REVISION_USER_HIT_PREFIX = "configRevisionUserHit";
+export const CURRENT_CONFIG_REVISION_CODE_KEY = "configRevisionCurrentCode";
+
+const SHARED_VARIABLE_PREFIXES = ["generic", "substitutions"];
+
+export interface ConfigRevisionReceipt {
+    code: string;
+    createdAt: number;
+    updatedBy?: string;
+    changedVariableKeys: string[];
+    changedEvaluatorShortnames: string[];
+    changedEvaluatorNames: string[];
+    appliesToAllEvaluators: boolean;
+}
+
+export interface ConfigRevisionUserHit {
+    username: string;
+    revisionCode: string;
+    evaluatorShortname: string;
+    evaluatorName: string;
+    caughtAt: number;
+    targetId?: string;
+    subreddit?: string;
+}
+
+export interface ConfigRevisionUserHitWithReceipt {
+    hit: ConfigRevisionUserHit;
+    receipt: ConfigRevisionReceipt;
+}
+
+function getVariablePrefix (variableKey: string): string {
+    return variableKey.split(":")[0] ?? variableKey;
+}
+
+function getEvaluatorNamesByShortname (): Record<string, string> {
+    return _.fromPairs(ALL_RELEVANT_EVALUTORS.map((Evaluator) => {
+        const evaluator = new Evaluator({} as unknown as TriggerContext, [], undefined, {});
+        return [evaluator.shortname, evaluator.name];
+    }));
+}
+
+function randomCodeSuffix (): string {
+    const characters = "abcdefghjkmnpqrstuvwxyz23456789";
+    let suffix = "";
+    for (let i = 0; i < 5; i++) {
+        suffix += characters[Math.floor(Math.random() * characters.length)];
+    }
+    return suffix;
+}
+
+function buildRevisionCode (createdAt: Date): string {
+    const timestamp = createdAt.toISOString()
+        .replace(/\.\d{3}Z$/, "Z")
+        .replace(/:/g, "-");
+    return `${timestamp}-${randomCodeSuffix()}`;
+}
+
+function receiptAppliesToEvaluator (receipt: ConfigRevisionReceipt, evaluatorShortname: string): boolean {
+    return receipt.appliesToAllEvaluators || receipt.changedEvaluatorShortnames.includes(evaluatorShortname);
+}
+
+export async function getConfigRevisionReceipt (code: string, context: Context | TriggerContext | JobContext): Promise<ConfigRevisionReceipt | undefined> {
+    const receiptRaw = await context.redis.global.hGet(CONFIG_REVISION_RECEIPTS_KEY, code);
+    if (!receiptRaw) {
+        return;
+    }
+
+    return JSON.parse(receiptRaw) as ConfigRevisionReceipt;
+}
+
+function getConfigRevisionUserHitKey (username: string): string {
+    return `${CONFIG_REVISION_USER_HIT_PREFIX}:${username}`;
+}
+
+async function cleanupOldConfigRevisionReceipts (context: JobContext | TriggerContext) {
+    const staleEntries = await context.redis.global.zRange(CONFIG_REVISION_RECENT_KEY, 0, subMinutes(new Date(), 60 * 24).getTime(), { by: "score" });
+    const staleCodes = staleEntries.map(entry => entry.member);
+    if (staleCodes.length === 0) {
+        return;
+    }
+
+    await context.redis.global.zRem(CONFIG_REVISION_RECENT_KEY, staleCodes);
+    await context.redis.global.hDel(CONFIG_REVISION_RECEIPTS_KEY, staleCodes);
+}
+
+export function getChangedVariableKeys (existingVariables: Record<string, string>, nextVariables: Record<string, string>): string[] {
+    const allKeys = _.uniq([...Object.keys(existingVariables), ...Object.keys(nextVariables)]);
+    return allKeys.filter(key => existingVariables[key] !== nextVariables[key]).sort();
+}
+
+export async function cacheCurrentConfigRevisionCodeLocally (context: TriggerContext | JobContext) {
+    if (context.subredditName === CONTROL_SUBREDDIT) {
+        return;
+    }
+
+    const revisionCode = await context.redis.global.get(CURRENT_CONFIG_REVISION_CODE_KEY);
+    if (!revisionCode) {
+        return;
+    }
+
+    await context.redis.set(CURRENT_CONFIG_REVISION_CODE_KEY, revisionCode, { expiration: addMinutes(new Date(), 5) });
+}
+
+export async function recordEvaluatorConfigRevisionReceipt (options: {
+    updatedBy?: string;
+    changedVariableKeys: string[];
+}, context: JobContext | TriggerContext): Promise<ConfigRevisionReceipt | undefined> {
+    if (options.changedVariableKeys.length === 0) {
+        return;
+    }
+
+    const createdAt = new Date();
+    const code = buildRevisionCode(createdAt);
+    const evaluatorNamesByShortname = getEvaluatorNamesByShortname();
+    const changedPrefixes = _.uniq(options.changedVariableKeys.map(getVariablePrefix));
+    const appliesToAllEvaluators = changedPrefixes.some(prefix => SHARED_VARIABLE_PREFIXES.includes(prefix));
+    const changedEvaluatorShortnames = changedPrefixes.filter(prefix => evaluatorNamesByShortname[prefix]).sort();
+    const changedEvaluatorNames = changedEvaluatorShortnames.map(shortname => evaluatorNamesByShortname[shortname]).sort();
+
+    const receipt: ConfigRevisionReceipt = {
+        code,
+        createdAt: createdAt.getTime(),
+        updatedBy: options.updatedBy,
+        changedVariableKeys: options.changedVariableKeys,
+        changedEvaluatorShortnames,
+        changedEvaluatorNames,
+        appliesToAllEvaluators,
+    };
+
+    await context.redis.global.hSet(CONFIG_REVISION_RECEIPTS_KEY, { [code]: JSON.stringify(receipt) });
+    await context.redis.global.zAdd(CONFIG_REVISION_RECENT_KEY, { member: code, score: receipt.createdAt });
+    await context.redis.global.set(CURRENT_CONFIG_REVISION_CODE_KEY, code);
+    await cleanupOldConfigRevisionReceipts(context);
+
+    return receipt;
+}
+
+export async function getLoadedConfigRevisionReceiptForEvaluator (evaluatorShortname: string, context: Context | TriggerContext | JobContext, withinMinutes = 60): Promise<ConfigRevisionReceipt | undefined> {
+    const loadedRevisionCode = context.subredditName === CONTROL_SUBREDDIT
+        ? await context.redis.global.get(CURRENT_CONFIG_REVISION_CODE_KEY)
+        : await context.redis.get(CURRENT_CONFIG_REVISION_CODE_KEY);
+
+    if (!loadedRevisionCode) {
+        return;
+    }
+
+    const receipt = await getConfigRevisionReceipt(loadedRevisionCode, context);
+    if (!receipt) {
+        return;
+    }
+
+    const cutoff = subMinutes(new Date(), withinMinutes).getTime();
+    if (receipt.createdAt < cutoff) {
+        return;
+    }
+
+    if (!receiptAppliesToEvaluator(receipt, evaluatorShortname)) {
+        return;
+    }
+
+    return receipt;
+}
+
+export async function recordConfigRevisionUserHit (hit: ConfigRevisionUserHit, context: Context | TriggerContext | JobContext) {
+    await context.redis.global.set(getConfigRevisionUserHitKey(hit.username), JSON.stringify(hit), { expiration: addHours(new Date(), 2) });
+}
+
+export async function getRecentConfigRevisionUserHit (username: string, context: Context | TriggerContext | JobContext, withinMinutes = 60): Promise<ConfigRevisionUserHitWithReceipt | undefined> {
+    const hitRaw = await context.redis.global.get(getConfigRevisionUserHitKey(username));
+    if (!hitRaw) {
+        return;
+    }
+
+    const hit = JSON.parse(hitRaw) as ConfigRevisionUserHit;
+    const receipt = await getConfigRevisionReceipt(hit.revisionCode, context);
+    if (!receipt) {
+        return;
+    }
+
+    const cutoff = subMinutes(new Date(), withinMinutes).getTime();
+    if (hit.caughtAt < cutoff || receipt.createdAt < cutoff) {
+        return;
+    }
+
+    return { hit, receipt };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,6 +44,7 @@ export enum ControlSubredditJob {
     DefinedHandlesPostStore = "definedHandlesPostStore",
     ClassificationReversals = "classificationReversals",
     PostCreationQueueReversals = "postCreationQueueReversals",
+    EmergencyConfigCleanup = "emergencyConfigCleanup",
     DeleteRecordsForRemovedUsers = "deleteRecordsForRemovedUsers",
     HandleConfigWikiChange = "handleConfigWikiChange",
     ConditionalStatsUpdate = "conditionalStatsUpdate",

--- a/src/externalSubmissions.ts
+++ b/src/externalSubmissions.ts
@@ -14,6 +14,7 @@ import { getEvaluatorVariables } from "./userEvaluation/evaluatorVariables.js";
 import { queueKarmaFarmingAccounts } from "./karmaFarmingSubsCheck.js";
 import { userIsTrustedSubmitter } from "./trustedSubmitterHelpers.js";
 import { expireKeyAt } from "devvit-helpers";
+import { ConfigRevisionUserHit, recordConfigRevisionUserHit } from "./configRevisionReceipts.js";
 
 const WIKI_PAGE = "externalsubmissions";
 
@@ -35,6 +36,7 @@ export interface ExternalSubmission {
     sendFeedback?: boolean;
     proactive?: boolean;
     immediate?: boolean;
+    configRevisionHit?: ConfigRevisionUserHit;
 };
 
 export async function addExternalSubmissionFromClientSub (data: ExternalSubmission, context: TriggerContext) {
@@ -54,6 +56,10 @@ export async function addExternalSubmissionFromClientSub (data: ExternalSubmissi
         await context.redis.global.zAdd(EXTERNAL_SUBMISSION_QUEUE_KEY, { member: data.username, score: new Date().getTime() });
         await context.redis.global.set(getExternalSubmissionDataKey(data.username), JSON.stringify(data), { expiration: addDays(new Date(), 7) });
         console.log(`External Submissions: Added external submission for ${data.username} to the queue.`);
+    }
+
+    if (data.configRevisionHit) {
+        await recordConfigRevisionUserHit(data.configRevisionHit, context);
     }
 
     if (data.targetId) {
@@ -152,6 +158,10 @@ export async function addExternalSubmissionToPostCreationQueue (item: ExternalSu
         commentToAdd = json2md(body);
     }
 
+    if (item.configRevisionHit) {
+        await recordConfigRevisionUserHit(item.configRevisionHit, context);
+    }
+
     const submission: AsyncSubmission = {
         user: await getUserExtendedFromUser(user, context),
         submitter: item.submitter,
@@ -168,6 +178,7 @@ export async function addExternalSubmissionToPostCreationQueue (item: ExternalSu
         removeComment: item.publicContext === false,
         reportContext: item.reportContext,
         evaluatorsChecked: item.evaluationResults !== undefined && item.evaluationResults.length > 0,
+        configRevisionHit: item.configRevisionHit,
     };
 
     const [result] = await queuePostCreation([submission], context);

--- a/src/handleClientPostOrComment.ts
+++ b/src/handleClientPostOrComment.ts
@@ -12,6 +12,7 @@ import { getEvaluatorVariables } from "./userEvaluation/evaluatorVariables.js";
 import { recordBanForSummary } from "./modmail/actionSummary.js";
 import { expireKeyAt, isBanned, isContributor } from "devvit-helpers";
 import { filterContent, fixCommentTriggerEvent, fixPostTriggerEvent, getPostOrCommentById, getUserExtended, hasTriggerBeenHandled } from "@fsvreddit/fsv-devvit-helpers";
+import { ConfigRevisionUserHit, getLoadedConfigRevisionReceiptForEvaluator, recordConfigRevisionUserHit } from "./configRevisionReceipts.js";
 
 export async function handleClientPostCreate (event: PostCreate, context: TriggerContext) {
     if (context.subredditName === CONTROL_SUBREDDIT) {
@@ -356,6 +357,7 @@ async function checkAndReportPotentialBot (username: string, target: Post | Comm
     let isLikelyBot = false;
     let anyEvaluatorsChecked = false;
     let botName: string | undefined;
+    let botShortname: string | undefined;
 
     let socialLinks: UserSocialLink[] | undefined;
 
@@ -413,6 +415,7 @@ async function checkAndReportPotentialBot (username: string, target: Post | Comm
         if (evaluationResult) {
             isLikelyBot = true;
             botName = evaluator.name;
+            botShortname = evaluator.shortname;
             break;
         }
     }
@@ -443,6 +446,23 @@ async function checkAndReportPotentialBot (username: string, target: Post | Comm
     const targetItem = await getPostOrCommentById(context.reddit, targetId);
     const reportContext = `Automatically reported via a [${isLinkId(targetItem.id) ? "post" : "comment"}](${targetItem.permalink}) on /r/${targetItem.subredditName}`;
 
+    let configRevisionHit: ConfigRevisionUserHit | undefined;
+    if (botShortname && botName) {
+        const revisionReceipt = await getLoadedConfigRevisionReceiptForEvaluator(botShortname, context);
+        if (revisionReceipt) {
+            configRevisionHit = {
+                username: user.username,
+                revisionCode: revisionReceipt.code,
+                evaluatorShortname: botShortname,
+                evaluatorName: botName,
+                caughtAt: Date.now(),
+                targetId: targetItem.id,
+                subreddit: targetItem.subredditName,
+            };
+            await recordConfigRevisionUserHit(configRevisionHit, context);
+        }
+    }
+
     await addExternalSubmissionFromClientSub({
         username: user.username,
         subreddit: context.subredditName,
@@ -450,6 +470,7 @@ async function checkAndReportPotentialBot (username: string, target: Post | Comm
         reportContext,
         immediate: true,
         targetId: targetItem.id,
+        configRevisionHit,
     }, context);
 
     console.log(`Created external submission via automated evaluation for ${user.username} for bot style ${botName}`);

--- a/src/handleReportUser.ts
+++ b/src/handleReportUser.ts
@@ -12,6 +12,7 @@ import { canUserReceiveFeedback } from "./submissionFeedback.js";
 import { isLinkId } from "@devvit/public-api/types/tid.js";
 import { addClassificationQueryToQueue } from "./modmail/classificationQuery.js";
 import { getPostOrCommentById } from "@fsvreddit/fsv-devvit-helpers";
+import { getRecentConfigRevisionUserHit } from "./configRevisionReceipts.js";
 
 enum ReportFormField {
     ReportContext = "reportContext",
@@ -21,7 +22,7 @@ enum ReportFormField {
 
 export const reportFormDefinition: FormFunction = data => ({
     title: `Report u/${data.username} to Bot Bouncer`,
-    description: "Thank you for reporting this user. Our team will review the account manually and take appropriate action.",
+    description: `Thank you for reporting this user. Our team will review the account manually and take appropriate action.${data.configRevisionNotice ? `\n\n${data.configRevisionNotice as string}` : ""}`,
     fields: [
         {
             type: "paragraph",
@@ -153,12 +154,24 @@ export async function handleReportUser (event: MenuItemOnPressEvent, context: Co
     }
 
     const canReceiveFeedback = await canUserReceiveFeedback(currentUser.username, context);
-    const data = {
+    const canSeeConfigRevisionNotice = await isModeratorWithCache(currentUser.username, context, CONTROL_SUBREDDIT);
+    const recentConfigRevisionHit = canSeeConfigRevisionNotice
+        ? await getRecentConfigRevisionUserHit(target.authorName, context)
+        : undefined;
+    const configRevisionNotice = recentConfigRevisionHit
+        ? `Recent evaluator revision context: ${recentConfigRevisionHit.hit.evaluatorName} matched this account under config revision \`${recentConfigRevisionHit.receipt.code}\`, saved ${new Date(recentConfigRevisionHit.receipt.createdAt).toISOString()}.`
+        : undefined;
+
+    const data: JSONObject = {
         username: target.authorName,
         userFeedbackPreference: await getUserFeedbackPreference(currentUser.username, context),
         feedbackHelpText: canReceiveFeedback ? "You must be able to receive chat messages from /u/bot-bouncer to receive this notification" : "We've tried to send feedback for you several times but this hasn't worked. Check to make sure you can receive chats from /u/bot-bouncer. This option will return within 24h.",
         feedbackDisabled: !canReceiveFeedback,
     };
+
+    if (configRevisionNotice) {
+        data.configRevisionNotice = configRevisionNotice;
+    }
 
     context.ui.showForm(reportForm, data);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { checkUptimeAndMessages } from "./uptimeMonitor.js";
 import { handleRapidJob } from "./scheduler/handleRapidJob.js";
 import { buildEvaluatorAccuracyStatistics } from "./statistics/evaluatorAccuracyStatistics.js";
 import { definedHandlesStatsInitializer, gatherDefinedHandlesStats, storeDefinedHandlesDataJob } from "./statistics/definedHandlesStatistics.js";
-import { deleteRecordsForRemovedUsers, classificationReversalsJob, reversePostCreationQueue } from "./modmail/evaluatorReversals.js";
+import { deleteRecordsForRemovedUsers, classificationReversalsJob, reversePostCreationQueue, emergencyConfigCleanupJob } from "./modmail/evaluatorReversals.js";
 import { handleCommentCreate, handlePostCreate, handlePostSubmit } from "./handleContentCreation.js";
 import { conditionalStatsUpdate } from "./statistics/conditionalStatsUpdate.js";
 import { asyncWikiUpdate } from "./statistics/asyncWikiUpdate.js";
@@ -209,6 +209,11 @@ Devvit.addSchedulerJob({
 Devvit.addSchedulerJob({
     name: ControlSubredditJob.PostCreationQueueReversals,
     onRun: reversePostCreationQueue,
+});
+
+Devvit.addSchedulerJob({
+    name: ControlSubredditJob.EmergencyConfigCleanup,
+    onRun: emergencyConfigCleanupJob,
 });
 
 Devvit.addSchedulerJob({

--- a/src/modmail/controlSubModmail.ts
+++ b/src/modmail/controlSubModmail.ts
@@ -18,7 +18,7 @@ import { FLAIR_MAPPINGS } from "../handleControlSubFlairUpdate.js";
 import _ from "lodash";
 import { CHECK_DATE_KEY } from "../karmaFarmingSubsCheck.js";
 import { evaluateAccountFromModmail } from "./modmailEvaluaton.js";
-import { handleReversalCommand } from "./evaluatorReversals.js";
+import { handleEmergencyCleanupCommand, handleReversalCommand } from "./evaluatorReversals.js";
 import { handleHighlightedModmail } from "./unhighlighter.js";
 import { getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
 import { generateOpenAISummary } from "../aiAnalysis/createAISummary.js";
@@ -52,6 +52,11 @@ export async function handleControlSubredditModmail (modmail: ModmailMessage, co
 
     if (modmail.bodyMarkdown.startsWith("!extract")) {
         await dataExtract(modmail, modmail.conversationId, context);
+        return;
+    }
+
+    if (modmail.bodyMarkdown.startsWith("!emergency-cleanup")) {
+        await handleEmergencyCleanupCommand(modmail, context);
         return;
     }
 

--- a/src/modmail/evaluatorReversals.ts
+++ b/src/modmail/evaluatorReversals.ts
@@ -1,6 +1,6 @@
-import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext } from "@devvit/public-api";
+import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext, WikiPagePermissionLevel } from "@devvit/public-api";
 import { deleteUserStatus, getUserStatus, updateAggregate, UserStatus } from "../dataStore.js";
-import { addDays, addMinutes, addSeconds } from "date-fns";
+import { addDays, addMinutes, addSeconds, format } from "date-fns";
 import { CONTROL_SUBREDDIT, ControlSubredditJob, PostFlairTemplate } from "../constants.js";
 import { deleteAccountInitialEvaluationResults, getAccountInitialEvaluationResults } from "../handleControlSubAccountEvaluation.js";
 import { CLEANUP_LOG_KEY } from "../cleanup.js";
@@ -9,6 +9,7 @@ import Ajv, { JSONSchemaType } from "ajv";
 import { AsyncSubmission } from "../postCreation.js";
 import pluralize from "pluralize";
 import json2md from "json2md";
+import { getConfigRevisionReceipt } from "../configRevisionReceipts.js";
 
 const REVERSED_USERS = "ReversedUsers";
 
@@ -136,6 +137,352 @@ export async function classificationReversalsJob (event: ScheduledJobEvent<JSONO
             reversedTotal,
         },
     });
+}
+
+interface EmergencyCleanupData {
+    code: string;
+    confirm?: boolean;
+    dryRun?: boolean;
+}
+
+const emergencyCleanupSchema: JSONSchemaType<EmergencyCleanupData> = {
+    type: "object",
+    properties: {
+        code: { type: "string" },
+        confirm: { type: "boolean", nullable: true },
+        dryRun: { type: "boolean", nullable: true },
+    },
+    required: ["code"],
+    additionalProperties: false,
+};
+
+function getEmergencyCleanupMatchesKey (cleanupId: string): string {
+    return `emergencyCleanupMatches:${cleanupId}`;
+}
+
+function getEmergencyCleanupRevisionText (receipt: Awaited<ReturnType<typeof getConfigRevisionReceipt>>): string {
+    if (!receipt) {
+        return "Unknown";
+    }
+
+    if (receipt.appliesToAllEvaluators) {
+        return "Shared evaluator variables";
+    }
+
+    if (receipt.changedEvaluatorNames.length > 0) {
+        return receipt.changedEvaluatorNames.join(", ");
+    }
+
+    return "Unknown evaluator variables";
+}
+
+export async function handleEmergencyCleanupCommand (message: ModmailMessage, context: TriggerContext) {
+    if (context.subredditName !== CONTROL_SUBREDDIT) {
+        throw new Error("Emergency cleanup commands can only be handled in the control subreddit.");
+    }
+
+    if (!message.bodyMarkdown.startsWith("!emergency-cleanup {")) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid command format. Use `!emergency-cleanup {\"code\":\"REVISION-CODE\",\"confirm\":true}` or `!emergency-cleanup {\"code\":\"REVISION-CODE\",\"dryRun\":true}`.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    let data: EmergencyCleanupData;
+    try {
+        data = JSON.parse(message.bodyMarkdown.replace("!emergency-cleanup ", "")) as EmergencyCleanupData;
+    } catch {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Invalid JSON format for the emergency-cleanup command.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const ajv = new Ajv.default();
+    const validate = ajv.compile(emergencyCleanupSchema);
+    if (!validate(data)) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: `❌ Invalid data for the emergency-cleanup command: ${ajv.errorsText(validate.errors)}`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (!data.confirm && !data.dryRun) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ Emergency cleanup requires either `confirm: true` or `dryRun: true`. No changes were made.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const receipt = await getConfigRevisionReceipt(data.code, context);
+    if (!receipt) {
+        await context.reddit.modMail.reply({
+            conversationId: message.conversationId,
+            body: "❌ The revision code was not found. It may be invalid or expired.",
+            isInternal: true,
+        });
+        return;
+    }
+
+    const cleanupId = Date.now().toString();
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.EmergencyConfigCleanup,
+        runAt: new Date(),
+        data: {
+            firstRun: true,
+            cleanupId,
+            code: data.code,
+            dryRun: data.dryRun === true,
+            conversationId: message.conversationId,
+            runBy: message.messageAuthor,
+            matchedTotal: 0,
+            removedTotal: 0,
+            invalidTotal: 0,
+        },
+    });
+
+    await context.reddit.modMail.reply({
+        conversationId: message.conversationId,
+        body: `${data.dryRun ? "Dry-run" : "Emergency cleanup"} scheduled for revision code ${data.code}. Bot Bouncer will reply with the extraction and cleanup report when complete.`,
+        isInternal: true,
+    });
+}
+
+export async function emergencyConfigCleanupJob (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
+    const conversationId = event.data?.conversationId as string | undefined;
+    const cleanupId = event.data?.cleanupId as string | undefined;
+    const code = event.data?.code as string | undefined;
+    const dryRun = event.data?.dryRun as boolean | undefined ?? false;
+    const runBy = event.data?.runBy as string | undefined ?? "unknown";
+    let matchedTotal = event.data?.matchedTotal as number | undefined ?? 0;
+    let removedTotal = event.data?.removedTotal as number | undefined ?? 0;
+    let invalidTotal = event.data?.invalidTotal as number | undefined ?? 0;
+
+    if (!conversationId || !cleanupId || !code) {
+        throw new Error("Emergency config cleanup job must be run with conversationId, cleanupId, and code.");
+    }
+
+    const receipt = await getConfigRevisionReceipt(code, context);
+    if (!receipt) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `❌ Emergency cleanup failed because revision code ${code} was not found.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    if (event.data?.firstRun) {
+        console.log(`Emergency Cleanup: Starting ${dryRun ? "dry-run" : "cleanup"} for config revision ${code}.`);
+        const submissionQueue = await context.redis.zRange(SUBMISSION_QUEUE, 0, -1);
+        await context.redis.del(getEmergencyCleanupMatchesKey(cleanupId));
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.EmergencyConfigCleanup,
+            runAt: new Date(),
+            data: {
+                firstRun: false,
+                cleanupId,
+                code,
+                dryRun,
+                queueUsers: submissionQueue.map(entry => entry.member),
+                conversationId,
+                runBy,
+                matchedTotal,
+                removedTotal,
+                invalidTotal,
+            },
+        });
+        return;
+    }
+
+    const runLimit = addSeconds(new Date(), 10);
+    const queueUsers = event.data?.queueUsers as string[] | undefined ?? [];
+
+    if (queueUsers.length === 0) {
+        const wikiLink = await writeEmergencyCleanupExtract(cleanupId, code, receipt, conversationId, dryRun, runBy, context);
+        await context.redis.del(getEmergencyCleanupMatchesKey(cleanupId));
+
+        const body: string[] = [
+            dryRun ? "✅ Emergency cleanup dry-run completed." : "✅ Emergency cleanup completed.",
+            "",
+            `Revision code: ${code}`,
+            `Revision saved: ${new Date(receipt.createdAt).toISOString()}`,
+            `Changed evaluator context: ${getEmergencyCleanupRevisionText(receipt)}`,
+            `Cleanup run by: u/${runBy}`,
+            "",
+            `Matching queue entries: ${matchedTotal.toLocaleString()}`,
+            dryRun ? "Queue entries removed: 0 (dry run)" : `Queue entries removed: ${removedTotal.toLocaleString()}`,
+        ];
+
+        if (invalidTotal > 0) {
+            body.push(`Queue entries skipped due to unreadable details: ${invalidTotal.toLocaleString()}`);
+        }
+
+        if (wikiLink) {
+            body.push("");
+            body.push(`Data extraction saved before cleanup: ${wikiLink}`);
+        } else {
+            body.push("");
+            body.push("No matching queue entries were found, so no extraction page was written.");
+        }
+
+        if (dryRun && matchedTotal > 0) {
+            body.push("");
+            body.push("To run the cleanup, use:");
+            body.push(`\`!emergency-cleanup {"code":"${code}","confirm":true}\``);
+        }
+
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: body.join("\n"),
+            isInternal: true,
+        });
+        return;
+    }
+
+    while (queueUsers.length > 0 && new Date() < runLimit) {
+        const username = queueUsers.shift();
+        if (!username) {
+            break;
+        }
+
+        const submissionDetailsRaw = await context.redis.hGet(SUBMISSION_DETAILS, username);
+        if (!submissionDetailsRaw) {
+            continue;
+        }
+
+        let submissionDetails: AsyncSubmission;
+        try {
+            submissionDetails = JSON.parse(submissionDetailsRaw) as AsyncSubmission;
+        } catch {
+            invalidTotal++;
+            continue;
+        }
+
+        if (submissionDetails.configRevisionHit?.revisionCode !== code) {
+            continue;
+        }
+
+        matchedTotal++;
+        await context.redis.hSet(getEmergencyCleanupMatchesKey(cleanupId), { [username]: submissionDetailsRaw });
+        await context.redis.expire(getEmergencyCleanupMatchesKey(cleanupId), 60 * 60);
+
+        if (!dryRun) {
+            const txn = await context.redis.watch();
+            await txn.multi();
+            await txn.zRem(SUBMISSION_QUEUE, [username]);
+            await txn.hDel(SUBMISSION_DETAILS, [username]);
+            await txn.exec();
+            await deleteAccountInitialEvaluationResults(username, context);
+            removedTotal++;
+            console.log(`Emergency Cleanup: Removed ${username} from the post creation queue for config revision ${code}.`);
+        }
+    }
+
+    await context.scheduler.runJob({
+        name: ControlSubredditJob.EmergencyConfigCleanup,
+        runAt: addSeconds(new Date(), 5),
+        data: {
+            firstRun: false,
+            cleanupId,
+            code,
+            dryRun,
+            queueUsers,
+            conversationId,
+            runBy,
+            matchedTotal,
+            removedTotal,
+            invalidTotal,
+        },
+    });
+}
+
+async function writeEmergencyCleanupExtract (
+    cleanupId: string,
+    code: string,
+    receipt: NonNullable<Awaited<ReturnType<typeof getConfigRevisionReceipt>>>,
+    conversationId: string,
+    dryRun: boolean,
+    runBy: string,
+    context: JobContext,
+): Promise<string | undefined> {
+    const rawData = await context.redis.hGetAll(getEmergencyCleanupMatchesKey(cleanupId));
+    const entries = Object.entries(rawData)
+        .map(([username, value]) => ({ username, submission: JSON.parse(value) as AsyncSubmission }))
+        .sort((a, b) => a.username.localeCompare(b.username));
+
+    if (entries.length === 0) {
+        return;
+    }
+
+    if (entries.length > 5000) {
+        await context.reddit.modMail.reply({
+            conversationId,
+            body: `Emergency cleanup matched ${entries.length.toLocaleString()} queue entries. This exceeds the 5,000-user wiki extraction limit, so the detailed table was not written.`,
+            isInternal: true,
+        });
+        return;
+    }
+
+    const headers = ["User", "Queued At", "Submitter", "Status", "Matched Evaluator", "Target Subreddit", "Target ID"];
+    const rows = entries.map((entry) => {
+        const queueTime = entry.submission.queueTime ?? entry.submission.details.reportedAt;
+        const targetId = entry.submission.configRevisionHit?.targetId ?? "";
+        return [
+            `[${entry.username}](https://www.reddit.com/user/${entry.username})`,
+            queueTime ? format(new Date(queueTime), "yyyy-MM-dd HH:mm") : "",
+            entry.submission.details.submitter ?? entry.submission.submitter ?? "",
+            entry.submission.details.userStatus,
+            entry.submission.configRevisionHit?.evaluatorName ?? "",
+            entry.submission.configRevisionHit?.subreddit ? `/r/${entry.submission.configRevisionHit.subreddit}` : "",
+            targetId ? `https://redd.it/${targetId.substring(3)}` : "",
+        ];
+    });
+
+    const content = json2md([
+        { h1: "Emergency cleanup data extraction" },
+        { p: `Revision code: ${code}` },
+        { p: `Revision saved: ${new Date(receipt.createdAt).toISOString()}` },
+        { p: `Changed evaluator context: ${getEmergencyCleanupRevisionText(receipt)}` },
+        { p: `Cleanup mode: ${dryRun ? "dry run" : "confirmed cleanup"}` },
+        { p: `Cleanup run by: u/${runBy}` },
+        { p: `Matched queued users: ${entries.length.toLocaleString()}` },
+        { table: { headers, rows } },
+    ]);
+
+    const subredditName = context.subredditName ?? CONTROL_SUBREDDIT;
+    const wikiPageName = "emergency-cleanup";
+    let wikiPageExists = true;
+    try {
+        await context.reddit.getWikiPage(subredditName, wikiPageName);
+    } catch {
+        wikiPageExists = false;
+    }
+
+    const result = await context.reddit.updateWikiPage({
+        subredditName,
+        page: wikiPageName,
+        content,
+    });
+
+    if (!wikiPageExists) {
+        await context.reddit.updateWikiPageSettings({
+            subredditName,
+            page: wikiPageName,
+            permLevel: WikiPagePermissionLevel.MODS_ONLY,
+            listed: true,
+        });
+    }
+
+    return `https://www.reddit.com/r/${subredditName}/wiki/${wikiPageName}?v=${result.revisionId}`;
 }
 
 interface PostCreationQueueData {

--- a/src/postCreation.ts
+++ b/src/postCreation.ts
@@ -8,6 +8,7 @@ import pluralize from "pluralize";
 import { queueSendFeedback } from "./submissionFeedback.js";
 import { formatTimeSince, isBannedWithCache, sendMessageToWebhook, updateWebhookMessage } from "./utility.js";
 import { isUserSubmitterOrMod } from "./cleanup.js";
+import { ConfigRevisionUserHit } from "./configRevisionReceipts.js";
 import { recordBotPostCreated } from "./scheduler/botPostMonitor.js";
 
 export const statusToFlair: Record<UserStatus, PostFlairTemplate> = {
@@ -37,6 +38,7 @@ export interface AsyncSubmission {
     reportContext?: string;
     evaluatorsChecked: boolean;
     queueTime?: number;
+    configRevisionHit?: ConfigRevisionUserHit;
 }
 
 export async function isUserAlreadyQueued (username: string, context: JobContext): Promise<boolean> {
@@ -240,6 +242,7 @@ export async function queuePostCreation (submissions: AsyncSubmission[], context
             continue;
         }
 
+        submission.queueTime = Date.now();
         submissionsToAdd[submission.user.username] = JSON.stringify(submission);
         queueEntriesToAdd.push({ member: submission.user.username, score });
         results.push(PostCreationQueueResult.Queued);

--- a/src/userEvaluation/evaluatorVariables.ts
+++ b/src/userEvaluation/evaluatorVariables.ts
@@ -9,6 +9,7 @@ import { EvaluateBotGroupAdvanced } from "@fsvreddit/bot-bouncer-evaluation/dist
 import { getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
 import { addSeconds } from "date-fns";
 import { checkNonexistentSubs } from "./subExistenceChecks.js";
+import { cacheCurrentConfigRevisionCodeLocally, getChangedVariableKeys, recordEvaluatorConfigRevisionReceipt } from "../configRevisionReceipts.js";
 import { recordEvaluatorConfigEditSummary } from "./configEditSummaries.js";
 
 const EVALUATOR_VARIABLES_KEY = "evaluatorVariablesHash";
@@ -51,6 +52,8 @@ export async function getEvaluatorVariables (context: TriggerContext | JobContex
             await context.redis.expire(EVALUATOR_VARIABLES_KEY, 300); // 5 minutes
             console.log(`Evaluator Variables: Refreshed ${Object.keys(allVariables).length} evaluator variables to subreddit ${subredditName} from global store.`);
         }
+
+        await cacheCurrentConfigRevisionCodeLocally(context);
     }
 
     return _.fromPairs(Object.entries(allVariables).map(([key, value]) => [key, JSON.parse(value)]));
@@ -221,6 +224,7 @@ export async function updateEvaluatorVariablesFromWikiHandler (event: ScheduledJ
     const converted = _.fromPairs(Object.entries(variables).map(([key, value]) => [key, JSON.stringify(value)]));
 
     const existingVariables = await context.redis.global.hGetAll(EVALUATOR_VARIABLES_KEY);
+    const changedVariableKeys = getChangedVariableKeys(existingVariables, converted);
     const keysToRemove = Object.keys(existingVariables).filter(key => !(key in converted));
 
     await context.redis.global.hSet(EVALUATOR_VARIABLES_KEY, converted);
@@ -244,8 +248,26 @@ export async function updateEvaluatorVariablesFromWikiHandler (event: ScheduledJ
     const newRevisions = _.fromPairs(pages.map(page => [page.name, page.revisionId]));
     await context.redis.hSet(EVALUATOR_VARIABLES_LAST_REVISIONS_KEY, newRevisions);
 
+    const revisionReceipt = await recordEvaluatorConfigRevisionReceipt({
+        updatedBy: event.data?.username as string | undefined,
+        changedVariableKeys,
+    }, context);
+
     const variablesCount = Object.keys(converted).length;
     console.log(`Evaluator Variables: Updated ${variablesCount} variables and removed ${keysToRemove.length} from wiki edit by /u/${event.data?.username as string | undefined ?? "unknown"}.`);
+
+    if (revisionReceipt) {
+        console.log(`Evaluator Variables: Config revision receipt ${revisionReceipt.code} recorded for ${changedVariableKeys.length} changed ${changedVariableKeys.length === 1 ? "variable" : "variables"}.`);
+        if (controlSubSettings.monitoringWebhook) {
+            let changedEvaluators = "unknown evaluator variables";
+            if (revisionReceipt.appliesToAllEvaluators) {
+                changedEvaluators = "shared evaluator variables";
+            } else if (revisionReceipt.changedEvaluatorNames.length > 0) {
+                changedEvaluators = revisionReceipt.changedEvaluatorNames.join(", ");
+            }
+            await sendMessageToWebhook(controlSubSettings.monitoringWebhook, `Config revision saved: ${revisionReceipt.code}\nUpdated by: u/${revisionReceipt.updatedBy ?? "unknown"}\nChanged: ${changedEvaluators}\nChanged variable count: ${changedVariableKeys.length}`);
+        }
+    }
 
     const compressedVariables = compressData(variables);
 


### PR DESCRIPTION
## Summary

Adds revision-scoped emergency cleanup for evaluator-config mistakes.

## Changes

- Creates a timestamped receipt and revision code when evaluator variables change.
- Records which evaluator modules or shared variables were changed.
- Propagates the active revision code to client subreddits when evaluator variables refresh.
- Associates accounts detected under a recent revision with that revision code.
- Shows recent revision context in the Report User form.
- Adds `!emergency-cleanup` with confirmed and dry-run modes.
- Removes only post-creation queue entries associated with the specified revision.
- Saves a moderator-only extraction before confirmed queue removal.
- Processes large queues across scheduled-job continuations.
- Removes stored initial-evaluation results for queue entries that are removed.

## Safety

- Cleanup requires an existing revision code.
- Destructive cleanup requires `"confirm": true`.
- `"dryRun": true` reports matches without removing queue entries.
- The command does not reverse unrelated classifications.

## Validation

```powershell
npm.cmd exec -- tsc --noEmit
npm.cmd exec -- eslint .
npm.cmd exec -- vitest run src/configRevisionReceipts.test.ts
npm.cmd test
git diff --check
```
