### PR TITLE
Add config edit statistics and combined moderator activity statistics page

### DIFF
--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -17,6 +17,7 @@ import { getPossibleSetStatusValues } from "./controlSubModmail.js";
 import { getUserSocialLinks } from "devvit-helpers";
 import { sendMessageOnDelay } from "./delayedSend.js";
 import { getEvaluatorVariables } from "../userEvaluation/evaluatorVariables.js";
+import { recordConfigEditSession } from "../statistics/moderatorActivityStatistics.js";
 
 const APPEAL_CONFIG_WIKI_PAGE = "appeal-config";
 const APPEAL_CONFIG_REDIS_KEY = "AppealConfig";
@@ -264,6 +265,7 @@ export async function validateAndSaveAppealConfig (username: string, context: Tr
         // Save the valid config to Redis
         await context.redis.set(APPEAL_CONFIG_REDIS_KEY, JSON.stringify(parsedConfigs));
         await context.redis.set(appealConfigRevisionKey, wikiPage.revisionId);
+        await recordConfigEditSession(username, context);
         console.log(`Appeal config updated to revision ${wikiPage.revisionId}`);
         return;
     }

--- a/src/modmail/bulkSubmission.ts
+++ b/src/modmail/bulkSubmission.ts
@@ -9,6 +9,7 @@ import pluralize from "pluralize";
 import { ModmailMessage } from "./modmail.js";
 import { getControlSubSettings } from "../settings.js";
 import markdownEscape from "markdown-escape";
+import { recordBulkSubmittedAccounts } from "../statistics/moderatorActivityStatistics.js";
 
 interface UserWithDetails {
     username: string;
@@ -160,9 +161,12 @@ export async function handleBulkSubmission (submitter: string, trusted: boolean,
         return false;
     }
 
+    const submittedAccountCounts: Record<string, number> = {};
     let queued = 0;
 
     if (data.usernames) {
+        submittedAccountCounts[submitter] = (submittedAccountCounts[submitter] ?? 0) + data.usernames.length;
+
         const initialStatus = trusted ? UserStatus.Banned : UserStatus.Pending;
         queued = await handleBulkItems(data.usernames.map(username => ({
             username,
@@ -173,6 +177,10 @@ export async function handleBulkSubmission (submitter: string, trusted: boolean,
     }
 
     if (data.userDetails) {
+        for (const entry of data.userDetails) {
+            submittedAccountCounts[entry.submitter] = (submittedAccountCounts[entry.submitter] ?? 0) + 1;
+        }
+
         const initialStatus = trusted ? UserStatus.Banned : UserStatus.Pending;
         queued = await handleBulkItems(data.userDetails.map(entry => ({
             username: entry.username,
@@ -182,6 +190,8 @@ export async function handleBulkSubmission (submitter: string, trusted: boolean,
         })), context);
     }
 
+    await Promise.all(Object.entries(submittedAccountCounts)
+        .map(([username, accountCount]) => recordBulkSubmittedAccounts(username, accountCount, `modmail:${conversationId}`, context)));
     await context.reddit.modMail.archiveConversation(conversationId);
 
     if (queued > 0) {

--- a/src/scheduler/fiveMinutelyJobs.ts
+++ b/src/scheduler/fiveMinutelyJobs.ts
@@ -4,6 +4,7 @@ import { processHighlightedModmailQueue } from "../modmail/unhighlighter.js";
 import { gatherTokenStatistics } from "../aiAnalysis/statistics.js";
 import { updateClassificationStatistics } from "../statistics/classificationStatistics.js";
 import { updateAppealStatistics } from "../statistics/appealStatistics.js";
+import { updateModeratorActivityStatistics } from "../statistics/moderatorActivityStatistics.js";
 
 export async function handleFiveMinutelyJob (_: unknown, context: JobContext) {
     if (context.subredditName !== CONTROL_SUBREDDIT) {
@@ -33,5 +34,6 @@ export async function handleFiveMinutelyJob (_: unknown, context: JobContext) {
         gatherTokenStatistics(context),
         updateClassificationStatistics(context),
         updateAppealStatistics(context),
+        updateModeratorActivityStatistics(context),
     ]);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import Ajv, { JSONSchemaType } from "ajv";
 import { addMinutes } from "date-fns";
 import json2md from "json2md";
 import { sendMessageToWebhook } from "./utility.js";
+import { recordConfigEditSession } from "./statistics/moderatorActivityStatistics.js";
 
 export const CONFIGURATION_DEFAULTS = {
     banMessage: `Bots and bot-like accounts are not welcome on /r/{subreddit}.
@@ -455,5 +456,6 @@ export async function validateControlSubConfigChange (username: string, context:
 
     await context.redis.set(redisKey, wikiPage.revisionId);
     await context.redis.global.set(CONTROL_SUB_SETTINGS_CACHE_KEY, wikiPage.content);
+    await recordConfigEditSession(username, context);
     console.log("Control sub settings validated successfully");
 }

--- a/src/statistics/moderatorActivityStatistics.ts
+++ b/src/statistics/moderatorActivityStatistics.ts
@@ -1,0 +1,189 @@
+import { JobContext, TriggerContext } from "@devvit/public-api";
+import { addDays, addHours, eachDayOfInterval, format, startOfDay, subDays } from "date-fns";
+import json2md from "json2md";
+
+const CONFIG_SESSION_GAP_MS = 60 * 60 * 1000;
+const METRICS = ["appeals", "classifications", "configSessions", "bulkAccounts"] as const;
+type ModeratorActivityMetric = typeof METRICS[number];
+
+type StatisticsContext = JobContext | TriggerContext;
+
+interface ModeratorActivityRow {
+    username: string;
+    appeals: number;
+    classifications: number;
+    configSessions: number;
+    bulkAccounts: number;
+}
+
+function appealKeyForDate (date = new Date()): string {
+    return `appealStatistics~${format(date, "yyyy-MM-dd")}`;
+}
+
+function classificationKeyForDate (date = new Date()): string {
+    return `classificationStatistics-${format(date, "yyyy-MM-dd")}`;
+}
+
+function moderatorActivityKeyForDate (metric: ModeratorActivityMetric, date = new Date()): string {
+    return `moderatorActivityStatistics:${metric}:${format(date, "yyyy-MM-dd")}`;
+}
+
+function getConfigLastEditKey (username: string): string {
+    return `moderatorActivityStatistics:configLastEdit:${username}`;
+}
+
+function getBulkSubmissionSourceKey (sourceId: string, username: string): string {
+    return `moderatorActivityStatistics:bulkSubmissionSource:${sourceId}:${username}`;
+}
+
+function shouldCountUsername (username: string | undefined, context: StatisticsContext): username is string {
+    return Boolean(username && username !== "unknown" && username !== context.appSlug);
+}
+
+export async function recordConfigEditSession (username: string | undefined, context: StatisticsContext) {
+    if (!shouldCountUsername(username, context)) {
+        return;
+    }
+
+    const now = Date.now();
+    const lastEditRaw = await context.redis.get(getConfigLastEditKey(username));
+    const lastEdit = lastEditRaw ? parseInt(lastEditRaw) : undefined;
+
+    if (!lastEdit || Number.isNaN(lastEdit) || now - lastEdit > CONFIG_SESSION_GAP_MS) {
+        const sessions = await context.redis.zIncrBy(moderatorActivityKeyForDate("configSessions"), username, 1);
+        console.log(`Moderator Activity Statistics: Counted config session for ${username}. Total sessions today: ${sessions}`);
+    }
+
+    await context.redis.set(getConfigLastEditKey(username), now.toString(), { expiration: addDays(new Date(), 2) });
+}
+
+export async function recordBulkSubmittedAccounts (username: string | undefined, accountCount: number, sourceId: string, context: StatisticsContext) {
+    if (!shouldCountUsername(username, context) || accountCount <= 0) {
+        return;
+    }
+
+    const dedupeKey = getBulkSubmissionSourceKey(sourceId, username);
+    if (await context.redis.exists(dedupeKey)) {
+        return;
+    }
+
+    await context.redis.set(dedupeKey, "true", { expiration: addDays(new Date(), 30) });
+    const submitted = await context.redis.zIncrBy(moderatorActivityKeyForDate("bulkAccounts"), username, accountCount);
+    console.log(`Moderator Activity Statistics: Counted ${accountCount} bulk submitted accounts for ${username}. Total submitted today: ${submitted}`);
+}
+
+function emptyRow (username: string): ModeratorActivityRow {
+    return {
+        username,
+        appeals: 0,
+        classifications: 0,
+        configSessions: 0,
+        bulkAccounts: 0,
+    };
+}
+
+function addScore (rows: Map<string, ModeratorActivityRow>, username: string, metric: ModeratorActivityMetric, score: number) {
+    if (!rows.has(username)) {
+        rows.set(username, emptyRow(username));
+    }
+
+    const row = rows.get(username);
+    if (!row) {
+        return;
+    }
+
+    row[metric] += score;
+}
+
+async function addScoresFromKey (rows: Map<string, ModeratorActivityRow>, key: string, metric: ModeratorActivityMetric, context: JobContext) {
+    const entries = await context.redis.zRange(key, 0, -1);
+    for (const { member, score } of entries) {
+        addScore(rows, member, metric, score);
+    }
+}
+
+async function getRowsForDates (dates: Date[], context: JobContext): Promise<ModeratorActivityRow[]> {
+    const rows = new Map<string, ModeratorActivityRow>();
+
+    await Promise.all(dates.flatMap(date => [
+        addScoresFromKey(rows, appealKeyForDate(date), "appeals", context),
+        addScoresFromKey(rows, classificationKeyForDate(date), "classifications", context),
+        addScoresFromKey(rows, moderatorActivityKeyForDate("configSessions", date), "configSessions", context),
+        addScoresFromKey(rows, moderatorActivityKeyForDate("bulkAccounts", date), "bulkAccounts", context),
+    ]));
+
+    return Array.from(rows.values()).sort((a, b) => {
+        const totalA = a.appeals + a.classifications + a.configSessions + a.bulkAccounts;
+        const totalB = b.appeals + b.classifications + b.configSessions + b.bulkAccounts;
+        if (totalA !== totalB) {
+            return totalB - totalA;
+        }
+        return a.username.localeCompare(b.username);
+    });
+}
+
+function formatNumber (value: number): string {
+    return value.toLocaleString();
+}
+
+function addActivityTable (wikiContent: json2md.DataObject[], rows: ModeratorActivityRow[], emptyMessage: string) {
+    if (rows.length === 0) {
+        wikiContent.push({ p: emptyMessage });
+        return;
+    }
+
+    wikiContent.push({
+        table: {
+            headers: ["Username", "Appeals", "Classifications", "Config sessions", "Bulk accounts submitted"],
+            rows: rows.map(row => [
+                `/u/${row.username}`,
+                formatNumber(row.appeals),
+                formatNumber(row.classifications),
+                formatNumber(row.configSessions),
+                formatNumber(row.bulkAccounts),
+            ]),
+        },
+    });
+}
+
+export async function updateModeratorActivityStatistics (context: JobContext) {
+    const runRecentlyKey = "moderatorActivityStatisticsRunRecently";
+    if (await context.redis.exists(runRecentlyKey)) {
+        return;
+    }
+    await context.redis.set(runRecentlyKey, Date.now().toString(), { expiration: addHours(new Date(), 1) });
+
+    const startDate = startOfDay(subDays(new Date(), 7));
+    const endDate = startOfDay(subDays(new Date(), 1));
+    const dayToDelete = subDays(new Date(), 8);
+    const allDaysInRange = eachDayOfInterval({ start: startDate, end: endDate });
+
+    await Promise.all(METRICS.map(metric => context.redis.del(moderatorActivityKeyForDate(metric, dayToDelete))));
+
+    const weekRows = await getRowsForDates(allDaysInRange, context);
+    const yesterdayRows = await getRowsForDates([subDays(new Date(), 1)], context);
+    const todayRows = await getRowsForDates([new Date()], context);
+
+    const wikiContent: json2md.DataObject[] = [
+        { h1: "Moderator activity statistics" },
+        { p: "This lists moderators who have handled Bot Bouncer review work or related maintenance within the last week." },
+        { p: "Config work is counted by session. One config session is counted when a moderator makes one or more config revisions without a gap of more than 60 minutes between revisions." },
+    ];
+
+    addActivityTable(wikiContent, weekRows, "No moderator activity was found for the last week.");
+
+    wikiContent.push({ h2: "Yesterday's activity (UTC)" });
+    addActivityTable(wikiContent, yesterdayRows, "No moderator activity was recorded yesterday.");
+
+    wikiContent.push({ h2: "Today's activity since midnight UTC" });
+    addActivityTable(wikiContent, todayRows, "No moderator activity has been recorded today.");
+
+    wikiContent.push({ p: "This page updates every hour, and may update more frequently." });
+
+    const subredditName = context.subredditName ?? await context.reddit.getCurrentSubredditName();
+    await context.reddit.updateWikiPage({
+        subredditName,
+        page: "statistics/moderatoractivity",
+        content: json2md(wikiContent),
+    });
+}

--- a/src/userEvaluation/evaluatorVariables.ts
+++ b/src/userEvaluation/evaluatorVariables.ts
@@ -10,6 +10,7 @@ import { getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
 import { addSeconds } from "date-fns";
 import { checkNonexistentSubs } from "./subExistenceChecks.js";
 import { recordEvaluatorConfigEditSummary } from "./configEditSummaries.js";
+import { recordConfigEditSession } from "../statistics/moderatorActivityStatistics.js";
 
 const EVALUATOR_VARIABLES_KEY = "evaluatorVariablesHash";
 const EVALUATOR_VARIABLES_YAML_PAGE_ROOT = "evaluator-config";
@@ -240,6 +241,8 @@ export async function updateEvaluatorVariablesFromWikiHandler (event: ScheduledJ
             revisionReason,
         }, context);
     }
+
+    await recordConfigEditSession(event.data?.username as string | undefined, context);
 
     const newRevisions = _.fromPairs(pages.map(page => [page.name, page.revisionId]));
     await context.redis.hSet(EVALUATOR_VARIABLES_LAST_REVISIONS_KEY, newRevisions);


### PR DESCRIPTION
## Summary

Adds a combined moderator activity statistics page for appeal, classification, config-edit, and bulk-submission activity.

## Changes

- Adds the private `statistics/moderatoractivity` wiki page.
- Reports appeal and classification activity from the existing statistics stores.
- Counts successful config changes by session rather than by individual save.
- Treats config changes separated by no more than 60 minutes as one session.
- Does not count appeal-config or control-settings changes that fail validation.
- Counts the number of accounts included in bulk submissions.
- Deduplicates repeated processing of the same bulk-submission conversation.
- Preserves the existing appeal, classification, and evaluator-config summary statistics.

## Validation

```powershell
npm.cmd exec -- tsc --noEmit
npm.cmd exec -- eslint .
npm.cmd test
git diff --check
```
