### PR TITLE
Add prior appeal history notice (Previous: #463)

### DIFF
--- a/src/modmail/controlSubModmail.ts
+++ b/src/modmail/controlSubModmail.ts
@@ -25,6 +25,7 @@ import { generateOpenAISummary } from "../aiAnalysis/createAISummary.js";
 import { handleAskAI } from "../aiAnalysis/askAI.js";
 import pluralize from "pluralize";
 import { abandonConversationProcessing, beginConversationProcessing, completeConversationProcessing } from "./conversationProcessing.js";
+import { addPriorAppealHistoryNotice, recordPriorAppealSubmission } from "./priorAppealHistory.js";
 
 export function getPossibleSetStatusValues (): string[] {
     return _.uniq([...FLAIR_MAPPINGS.map(entry => entry.postFlair), ...Object.values(UserStatus)]);
@@ -215,6 +216,7 @@ async function handleModmailFromUser (modmail: ModmailMessage, context: TriggerC
 }
 
 async function processModmailFromUser (modmail: ModmailMessage, context: TriggerContext) {
+    const controlSubSettings = await getControlSubSettings(context);
     const username = modmail.messageAuthor;
 
     if (username === INTERNAL_BOT || username.startsWith(context.appSlug)) {
@@ -289,6 +291,11 @@ async function processModmailFromUser (modmail: ModmailMessage, context: Trigger
         // User is not banned or purged, so we should not send the "Appeal Received" message.
         return;
     }
+
+    // Duplicate appeals receive the recent-appeal automated reply and return above.
+    // Only show and record prior appeal history for appeals that proceed past that check.
+    await addPriorAppealHistoryNotice(modmail, controlSubSettings, context);
+    await recordPriorAppealSubmission(modmail, currentStatus, controlSubSettings, context);
 
     const user = await getUserOrUndefined(username, context);
     if (!user) {

--- a/src/modmail/priorAppealHistory.test.ts
+++ b/src/modmail/priorAppealHistory.test.ts
@@ -1,0 +1,214 @@
+import type { TriggerContext } from "@devvit/public-api";
+import { UserStatus } from "../dataStore.js";
+import type { UserDetails } from "../dataStore.js";
+import type { ControlSubSettings } from "../settings.js";
+import type { ModmailMessage } from "./modmail.js";
+import {
+    addPriorAppealHistoryNotice,
+    getPriorAppealHistoryWarningDays,
+    getRecentPriorAppeals,
+    parsePriorAppealRecord,
+    recordPriorAppealSubmission,
+} from "./priorAppealHistory.js";
+
+interface SetOptions {
+    nx?: boolean;
+}
+
+interface ZMember {
+    member: string;
+    score: number;
+}
+
+function settings (priorAppealHistoryWarningDays?: number): ControlSubSettings {
+    return {
+        evaluationDisabled: false,
+        reporterBlacklist: [],
+        trustedSubmitters: [],
+        priorAppealHistoryWarningDays,
+    };
+}
+
+function modmail (conversationId: string, participant = "TestUser"): ModmailMessage {
+    return {
+        conversationId,
+        subject: `Ban dispute for /u/${participant} on /r/TestSub`,
+        participant,
+        messageAuthor: participant,
+        messageAuthorIsMod: false,
+        bodyMarkdown: "Please review my appeal.",
+        isFirstMessage: true,
+        isInternal: false,
+    };
+}
+
+function userDetails (status: UserStatus.Banned | UserStatus.Purged = UserStatus.Banned): UserDetails {
+    return {
+        trackingPostId: "t3_test",
+        userStatus: status,
+        lastUpdate: Date.now(),
+        reportedAt: Date.now() - 60_000,
+    };
+}
+
+function createContext () {
+    const strings = new Map<string, string>();
+    const sortedSets = new Map<string, Map<string, number>>();
+    const replies: { conversationId: string; body: string; isInternal?: boolean }[] = [];
+    let replyError: Error | undefined;
+
+    const redis = {
+        get: (key: string) => Promise.resolve(strings.get(key)),
+        set: (key: string, value: string, options?: SetOptions) => {
+            if (!options?.nx || !strings.has(key)) {
+                strings.set(key, value);
+            }
+            return Promise.resolve();
+        },
+        exists: (key: string) => Promise.resolve(strings.has(key)),
+        del: (key: string) => Promise.resolve(strings.delete(key) ? 1 : 0),
+        expire: () => Promise.resolve(true),
+        zAdd: (key: string, value: ZMember) => {
+            const entries = sortedSets.get(key) ?? new Map<string, number>();
+            entries.set(value.member, value.score);
+            sortedSets.set(key, entries);
+            return Promise.resolve(1);
+        },
+        zRem: (key: string, members: string[]) => {
+            const entries = sortedSets.get(key);
+            let removed = 0;
+            for (const member of members) {
+                if (entries?.delete(member)) {
+                    removed++;
+                }
+            }
+            return Promise.resolve(removed);
+        },
+        zRemRangeByScore: (key: string, min: number, max: number) => {
+            const entries = sortedSets.get(key);
+            let removed = 0;
+            for (const [member, score] of entries ?? []) {
+                if (score >= min && score <= max) {
+                    entries?.delete(member);
+                    removed++;
+                }
+            }
+            return Promise.resolve(removed);
+        },
+        zRange: (key: string, min: number, max: number, options?: { reverse?: boolean }) => {
+            const entries = [...(sortedSets.get(key)?.entries() ?? [])]
+                .filter(([, score]) => score >= min && score <= max)
+                .map(([member, score]) => ({ member, score }))
+                .sort((a, b) => options?.reverse ? b.score - a.score : a.score - b.score);
+            return Promise.resolve(entries);
+        },
+    };
+
+    const context = {
+        redis,
+        reddit: {
+            modMail: {
+                reply: (reply: { conversationId: string; body: string; isInternal?: boolean }) => {
+                    if (replyError) {
+                        const error = replyError;
+                        replyError = undefined;
+                        return Promise.reject(error);
+                    }
+                    replies.push(reply);
+                    return Promise.resolve();
+                },
+            },
+        },
+    } as unknown as TriggerContext;
+
+    return {
+        context,
+        replies,
+        redis,
+        setReplyError: (error: Error) => {
+            replyError = error;
+        },
+    };
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+test("prior appeal history warning days is disabled when no positive setting is configured", () => {
+    expect(getPriorAppealHistoryWarningDays(settings())).toBeUndefined();
+    expect(getPriorAppealHistoryWarningDays(settings(0))).toBeUndefined();
+    expect(getPriorAppealHistoryWarningDays(settings(-1))).toBeUndefined();
+});
+
+test("prior appeal history warning days uses configured positive values", () => {
+    expect(getPriorAppealHistoryWarningDays(settings(14))).toBe(14);
+    expect(getPriorAppealHistoryWarningDays(settings(45))).toBe(45);
+});
+
+test("malformed prior appeal records are ignored", () => {
+    expect(parsePriorAppealRecord("not json")).toBeUndefined();
+    expect(parsePriorAppealRecord(JSON.stringify({ conversationId: "abc" }))).toBeUndefined();
+});
+
+test("recording is idempotent and usernames are normalized", async () => {
+    const { context } = createContext();
+    const appeal = modmail("conversation-1", "MixedCaseUser");
+
+    await recordPriorAppealSubmission(appeal, userDetails(), settings(30), context);
+    await recordPriorAppealSubmission(appeal, userDetails(), settings(30), context);
+
+    const records = await getRecentPriorAppeals("mixedcaseuser", 30, "different-conversation", context);
+    expect(records).toHaveLength(1);
+    expect(records[0].username).toBe("mixedcaseuser");
+    expect(records[0].conversationId).toBe("conversation-1");
+});
+
+test("concurrent appeal records do not overwrite each other", async () => {
+    const { context } = createContext();
+
+    await Promise.all([
+        recordPriorAppealSubmission(modmail("conversation-1"), userDetails(), settings(30), context),
+        recordPriorAppealSubmission(modmail("conversation-2"), userDetails(), settings(30), context),
+    ]);
+
+    const records = await getRecentPriorAppeals("TESTUSER", 30, "conversation-3", context);
+    expect(records.map(record => record.conversationId).sort()).toEqual(["conversation-1", "conversation-2"]);
+});
+
+test("expired appeal records are omitted from recent history", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00Z"));
+    const { context } = createContext();
+
+    await recordPriorAppealSubmission(modmail("old-conversation"), userDetails(), settings(7), context);
+    vi.setSystemTime(new Date("2026-01-09T12:00:00Z"));
+
+    await expect(getRecentPriorAppeals("TestUser", 7, "current-conversation", context)).resolves.toEqual([]);
+});
+
+test("notice is neutral, internal, and sent only once", async () => {
+    const { context, replies } = createContext();
+    await recordPriorAppealSubmission(modmail("previous-conversation"), userDetails(), settings(30), context);
+
+    const currentAppeal = modmail("current-conversation");
+    await addPriorAppealHistoryNotice(currentAppeal, settings(30), context);
+    await addPriorAppealHistoryNotice(currentAppeal, settings(30), context);
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0].isInternal).toBe(true);
+    expect(replies[0].body).toContain("previous-conversation");
+    expect(replies[0].body).toContain("does not indicate whether any prior appeal was granted, denied, or resolved");
+});
+
+test("failed notice delivery releases its lock for retry", async () => {
+    const { context, replies, setReplyError } = createContext();
+    await recordPriorAppealSubmission(modmail("previous-conversation"), userDetails(), settings(30), context);
+
+    const currentAppeal = modmail("current-conversation");
+    setReplyError(new Error("temporary failure"));
+    await expect(addPriorAppealHistoryNotice(currentAppeal, settings(30), context)).rejects.toThrow("temporary failure");
+    await addPriorAppealHistoryNotice(currentAppeal, settings(30), context);
+
+    expect(replies).toHaveLength(1);
+});

--- a/src/modmail/priorAppealHistory.ts
+++ b/src/modmail/priorAppealHistory.ts
@@ -1,0 +1,251 @@
+import type { TriggerContext } from "@devvit/public-api";
+import { addDays, addMinutes } from "date-fns";
+import json2md from "json2md";
+import { UserStatus } from "../dataStore.js";
+import type { UserDetails } from "../dataStore.js";
+import type { ControlSubSettings } from "../settings.js";
+import type { ModmailMessage } from "./modmail.js";
+
+const MAX_PRIOR_APPEALS_TO_SHOW = 5;
+const PRIOR_APPEAL_NOTICE_LOCK_MINUTES = 10;
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+export interface PriorAppealRecord {
+    username: string;
+    receivedAt: number;
+    conversationId: string;
+    userStatusAtAppeal: UserStatus.Banned | UserStatus.Purged;
+    appealedSubreddit?: string;
+    banDate?: number;
+}
+
+export function getPriorAppealHistoryWarningDays (settings: ControlSubSettings): number | undefined {
+    if (!settings.priorAppealHistoryWarningDays || settings.priorAppealHistoryWarningDays <= 0) {
+        return undefined;
+    }
+
+    return settings.priorAppealHistoryWarningDays;
+}
+
+function normalizeUsername (username: string): string {
+    return username.toLowerCase();
+}
+
+function getPriorAppealHistoryIndexKey (username: string): string {
+    return `priorAppealHistoryIndex~${normalizeUsername(username)}`;
+}
+
+function getPriorAppealRecordKey (conversationId: string): string {
+    return `priorAppealHistoryRecord~${conversationId}`;
+}
+
+function getPriorAppealHistoryNoticeKey (conversationId: string): string {
+    return `priorAppealHistoryNotice~${conversationId}`;
+}
+
+function getPriorAppealHistoryNoticeLockKey (conversationId: string): string {
+    return `priorAppealHistoryNoticeLock~${conversationId}`;
+}
+
+function getAppealedSubredditFromSubject (subject: string): string | undefined {
+    const match = /\bon\s+\/r\/([A-Za-z0-9_]+)/i.exec(subject);
+    return match?.[1];
+}
+
+function formatUtcDate (timestamp: number | undefined): string {
+    if (!timestamp) {
+        return "unknown date";
+    }
+
+    return `${new Date(timestamp).toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
+
+function getConversationLink (conversationId: string): string {
+    return `https://mod.reddit.com/mail/all/${conversationId}`;
+}
+
+export function parsePriorAppealRecord (recordData: string | undefined): PriorAppealRecord | undefined {
+    if (!recordData) {
+        return;
+    }
+
+    try {
+        const record = JSON.parse(recordData) as unknown;
+        if (!record || typeof record !== "object") {
+            return;
+        }
+
+        const candidate = record as Partial<PriorAppealRecord>;
+        if (typeof candidate.username !== "string"
+            || typeof candidate.receivedAt !== "number"
+            || !Number.isFinite(candidate.receivedAt)
+            || typeof candidate.conversationId !== "string"
+            || (candidate.userStatusAtAppeal !== UserStatus.Banned && candidate.userStatusAtAppeal !== UserStatus.Purged)
+            || (candidate.appealedSubreddit !== undefined && typeof candidate.appealedSubreddit !== "string")
+            || (candidate.banDate !== undefined && (typeof candidate.banDate !== "number" || !Number.isFinite(candidate.banDate)))) {
+            return;
+        }
+
+        return candidate as PriorAppealRecord;
+    } catch {
+        return;
+    }
+}
+
+export async function getRecentPriorAppeals (
+    username: string,
+    warningDays: number,
+    currentConversationId: string,
+    context: TriggerContext,
+): Promise<PriorAppealRecord[]> {
+    const normalizedUsername = normalizeUsername(username);
+    const indexKey = getPriorAppealHistoryIndexKey(normalizedUsername);
+    const cutoff = addDays(new Date(), -warningDays).getTime();
+
+    await context.redis.zRemRangeByScore(indexKey, 0, cutoff - 1);
+    const indexedRecords = await context.redis.zRange(indexKey, cutoff, Date.now(), { by: "score", reverse: true });
+
+    const invalidConversationIds: string[] = [];
+    const records: PriorAppealRecord[] = [];
+    for (const indexedRecord of indexedRecords) {
+        const record = parsePriorAppealRecord(await context.redis.get(getPriorAppealRecordKey(indexedRecord.member)));
+        if (!record
+            || normalizeUsername(record.username) !== normalizedUsername
+            || record.conversationId !== indexedRecord.member
+            || record.receivedAt < cutoff) {
+            invalidConversationIds.push(indexedRecord.member);
+            continue;
+        }
+
+        if (record.conversationId !== currentConversationId) {
+            records.push(record);
+        }
+    }
+
+    if (invalidConversationIds.length > 0) {
+        await context.redis.zRem(indexKey, invalidConversationIds);
+    }
+
+    return records
+        .sort((a, b) => b.receivedAt - a.receivedAt)
+        .slice(0, MAX_PRIOR_APPEALS_TO_SHOW);
+}
+
+export async function recordPriorAppealSubmission (
+    modmail: ModmailMessage,
+    userDetails: UserDetails,
+    settings: ControlSubSettings,
+    context: TriggerContext,
+): Promise<void> {
+    const username = modmail.participant;
+    if (!username || (userDetails.userStatus !== UserStatus.Banned && userDetails.userStatus !== UserStatus.Purged)) {
+        return;
+    }
+
+    const warningDays = getPriorAppealHistoryWarningDays(settings);
+    if (!warningDays) {
+        return;
+    }
+
+    const recordKey = getPriorAppealRecordKey(modmail.conversationId);
+    const candidateRecord: PriorAppealRecord = {
+        username: normalizeUsername(username),
+        receivedAt: Date.now(),
+        conversationId: modmail.conversationId,
+        userStatusAtAppeal: userDetails.userStatus,
+        appealedSubreddit: getAppealedSubredditFromSubject(modmail.subject),
+        banDate: userDetails.reportedAt ?? userDetails.lastUpdate,
+    };
+
+    await context.redis.set(recordKey, JSON.stringify(candidateRecord), {
+        nx: true,
+        expiration: addDays(new Date(), warningDays),
+    });
+
+    const storedRecord = parsePriorAppealRecord(await context.redis.get(recordKey));
+    if (!storedRecord || normalizeUsername(storedRecord.username) !== normalizeUsername(username)) {
+        console.warn(`Prior Appeal History: Could not read a valid record for conversation ${modmail.conversationId}.`);
+        return;
+    }
+
+    const indexKey = getPriorAppealHistoryIndexKey(username);
+    await context.redis.zAdd(indexKey, {
+        member: storedRecord.conversationId,
+        score: storedRecord.receivedAt,
+    });
+    await context.redis.expire(indexKey, warningDays * SECONDS_PER_DAY);
+}
+
+async function releaseNoticeLock (lockKey: string, token: string, context: TriggerContext): Promise<void> {
+    if (await context.redis.get(lockKey) === token) {
+        await context.redis.del(lockKey);
+    }
+}
+
+export async function addPriorAppealHistoryNotice (
+    modmail: ModmailMessage,
+    settings: ControlSubSettings,
+    context: TriggerContext,
+): Promise<void> {
+    const username = modmail.participant;
+    if (!username) {
+        return;
+    }
+
+    const warningDays = getPriorAppealHistoryWarningDays(settings);
+    if (!warningDays) {
+        return;
+    }
+
+    const noticeKey = getPriorAppealHistoryNoticeKey(modmail.conversationId);
+    if (await context.redis.exists(noticeKey)) {
+        return;
+    }
+
+    const lockKey = getPriorAppealHistoryNoticeLockKey(modmail.conversationId);
+    const token = `${Date.now()}:${Math.random()}`;
+    await context.redis.set(lockKey, token, {
+        nx: true,
+        expiration: addMinutes(new Date(), PRIOR_APPEAL_NOTICE_LOCK_MINUTES),
+    });
+
+    if (await context.redis.get(lockKey) !== token) {
+        return;
+    }
+
+    try {
+        if (await context.redis.exists(noticeKey)) {
+            return;
+        }
+
+        const recentRecords = await getRecentPriorAppeals(username, warningDays, modmail.conversationId, context);
+        if (recentRecords.length === 0) {
+            return;
+        }
+
+        const appealBullets = recentRecords.map((record) => {
+            const appealedSubreddit = record.appealedSubreddit ? `/r/${record.appealedSubreddit}` : "unknown subreddit";
+            return `${formatUtcDate(record.receivedAt)} — ${appealedSubreddit} — account status at appeal: ${record.userStatusAtAppeal} — ban recorded: ${formatUtcDate(record.banDate)} — ${getConversationLink(record.conversationId)}`;
+        });
+
+        const message: json2md.DataObject[] = [
+            { p: "Prior appeal history detected." },
+            { p: `/u/${username} has submitted ${recentRecords.length} previous Bot Bouncer ${recentRecords.length === 1 ? "appeal" : "appeals"} within the configured lookback window.` },
+            { ul: appealBullets },
+            { p: "This notice is informational only. It does not indicate whether any prior appeal was granted, denied, or resolved." },
+            { p: "Appeals that receive the automated recent-appeal reply are not recorded in this history and do not receive this notice." },
+        ];
+
+        await context.reddit.modMail.reply({
+            conversationId: modmail.conversationId,
+            body: json2md(message),
+            isInternal: true,
+        });
+
+        await context.redis.set(noticeKey, Date.now().toString(), {
+            expiration: addDays(new Date(), warningDays),
+        });
+    } finally {
+        await releaseNoticeLock(lockKey, token, context);
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -318,6 +318,7 @@ export interface ControlSubSettings {
     openAIMinimumContentCount?: number;
     openAINotificationsWebhook?: string;
     appRemovedMessage?: string;
+    priorAppealHistoryWarningDays?: number;
 }
 
 const CONTROL_SUB_SETTINGS_WIKI_PAGE = "control-sub-settings";
@@ -363,6 +364,7 @@ const schema: JSONSchemaType<ControlSubSettings> = {
         openAIMinimumContentCount: { type: "number", nullable: true },
         openAINotificationsWebhook: { type: "string", nullable: true },
         appRemovedMessage: { type: "string", nullable: true },
+        priorAppealHistoryWarningDays: { type: "number", nullable: true },
     },
     required: ["evaluationDisabled", "trustedSubmitters", "reporterBlacklist"],
 };


### PR DESCRIPTION
## Summary

Adds a moderator-only notice when a user submits a new appeal after one or more recent prior appeals.

The notice is intentionally neutral. It reports prior appeal conversations and dates without inferring whether those appeals were granted, denied, or otherwise resolved.

## Dependency

This is a stacked pull request based on `appeal-processing-reliability` and should be merged after PR #498. After #498 merges, this PR should be retargeted to `main` before the dependency branch is deleted.

## Changes

- Stores each recognized appeal as an idempotent per-conversation record.
- Maintains a normalized per-user sorted index for recent appeal lookup.
- Prevents concurrent appeal submissions from overwriting one another.
- Excludes the current conversation and appeals stopped by the immediate duplicate-appeal response.
- Limits the notice to the five most recent appeals within the configured lookback period.
- Removes stale or malformed index entries during lookup.
- Uses a short-lived delivery lock and durable completion marker to prevent duplicate moderator notices while allowing failed deliveries to retry.
- Preserves the existing temporary-ban information shown by `!checkban`.

## Tests

Regression coverage includes:

- disabled and positive lookback settings;
- malformed stored records;
- idempotent duplicate recording;
- username case normalization;
- concurrent appeal writes;
- expired record exclusion;
- neutral moderator-only notice generation;
- duplicate-notice prevention; and
- retry after a temporary notice-delivery failure.

## Validation

```powershell
npm.cmd exec -- tsc --noEmit
npm.cmd exec -- eslint .
npm.cmd test
```
