### PR TITLE
Fix automatic review safeguard conditions

### DIFF
--- a/src/handleControlSubAccountEvaluation.test.ts
+++ b/src/handleControlSubAccountEvaluation.test.ts
@@ -105,3 +105,19 @@ test("continuous NSFW history rejects a month containing only SFW activity", asy
 
     await expect(userHasContinuousNSFWHistory("testuser", createContext(posts))).resolves.toBe(false);
 });
+
+test("continuous NSFW history uses calendar months on the first day of a month", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T00:05:00Z"));
+
+    const posts = monthlyPosts([
+        "2026-02-28T23:59:00Z",
+        "2026-03-31T23:59:00Z",
+        "2026-04-30T23:59:00Z",
+        "2026-05-31T23:59:00Z",
+        "2026-06-30T23:59:00Z",
+        "2026-07-01T00:01:00Z",
+    ]);
+
+    await expect(userHasContinuousNSFWHistory("testuser", createContext(posts))).resolves.toBe(true);
+});

--- a/src/handleControlSubAccountEvaluation.test.ts
+++ b/src/handleControlSubAccountEvaluation.test.ts
@@ -1,0 +1,107 @@
+import type { Post, TriggerContext } from "@devvit/public-api";
+import { userHasContinuousNSFWHistory } from "./handleControlSubAccountEvaluation.js";
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+interface TestPost {
+    createdAt: Date;
+    nsfw: boolean;
+    subredditName: string;
+}
+
+function createContext (posts: TestPost[], nsfwSubreddits: string[] = []): TriggerContext {
+    const cache = new Map<string, string>();
+
+    return {
+        reddit: {
+            getPostsByUser: () => ({
+                all: () => Promise.resolve(posts as unknown as Post[]),
+            }),
+            getSubredditInfoByName: (subredditName: string) => Promise.resolve({
+                isNsfw: nsfwSubreddits.includes(subredditName),
+            }),
+        },
+        redis: {
+            get: (key: string) => Promise.resolve(cache.get(key)),
+            set: (key: string, value: string) => {
+                cache.set(key, value);
+                return Promise.resolve();
+            },
+        },
+    } as unknown as TriggerContext;
+}
+
+function monthlyPosts (dates: string[], nsfw = true, subredditName = "testsub"): TestPost[] {
+    return dates.map(date => ({
+        createdAt: new Date(date),
+        nsfw,
+        subredditName,
+    }));
+}
+
+test("continuous NSFW history handles a six-month window across a year boundary", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+
+    const posts = monthlyPosts([
+        "2025-08-01T12:00:00Z",
+        "2025-09-01T12:00:00Z",
+        "2025-10-01T12:00:00Z",
+        "2025-11-01T12:00:00Z",
+        "2025-12-01T12:00:00Z",
+        "2026-01-01T12:00:00Z",
+    ]);
+
+    await expect(userHasContinuousNSFWHistory("testuser", createContext(posts))).resolves.toBe(true);
+});
+
+test("continuous NSFW history counts posts made in NSFW subreddits", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+
+    const posts = monthlyPosts([
+        "2026-02-01T12:00:00Z",
+        "2026-03-01T12:00:00Z",
+        "2026-04-01T12:00:00Z",
+        "2026-05-01T12:00:00Z",
+        "2026-06-01T12:00:00Z",
+        "2026-07-01T12:00:00Z",
+    ], false, "nsfwcommunity");
+
+    await expect(userHasContinuousNSFWHistory("testuser", createContext(posts, ["nsfwcommunity"]))).resolves.toBe(true);
+});
+
+test("continuous NSFW history requires qualifying activity in every month", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+
+    const posts = monthlyPosts([
+        "2026-02-01T12:00:00Z",
+        "2026-03-01T12:00:00Z",
+        "2026-04-01T12:00:00Z",
+        "2026-06-01T12:00:00Z",
+        "2026-07-01T12:00:00Z",
+    ]);
+
+    await expect(userHasContinuousNSFWHistory("testuser", createContext(posts))).resolves.toBe(false);
+});
+
+test("continuous NSFW history rejects a month containing only SFW activity", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+
+    const posts = monthlyPosts([
+        "2026-02-01T12:00:00Z",
+        "2026-03-01T12:00:00Z",
+        "2026-04-01T12:00:00Z",
+        "2026-05-01T12:00:00Z",
+        "2026-06-01T12:00:00Z",
+        "2026-07-01T12:00:00Z",
+    ]);
+    posts[3].nsfw = false;
+    posts[3].subredditName = "sfwcommunity";
+
+    await expect(userHasContinuousNSFWHistory("testuser", createContext(posts))).resolves.toBe(false);
+});

--- a/src/handleControlSubAccountEvaluation.ts
+++ b/src/handleControlSubAccountEvaluation.ts
@@ -4,7 +4,7 @@ import { getUserStatus, UserStatus } from "./dataStore.js";
 import { ALL_RELEVANT_EVALUTORS, CONTROL_SUBREDDIT, ControlSubredditJob, PostFlairTemplate } from "./constants.js";
 import { getEvaluatorVariables } from "./userEvaluation/evaluatorVariables.js";
 import { createUserSummary } from "./UserSummary/userSummary.js";
-import { addSeconds, addWeeks, subMonths } from "date-fns";
+import { addSeconds, addWeeks, isSameMonth, startOfMonth, subMonths } from "date-fns";
 import _ from "lodash";
 import { getSubmitterSuccessRate } from "./statistics/submitterStatistics.js";
 import { conditionallyCompressString, conditionallyDecompressString } from "./utility.js";
@@ -301,11 +301,15 @@ export async function userHasContinuousNSFWHistory (username: string, context: T
         return false;
     }
 
+    const currentMonth = startOfMonth(new Date());
+    const firstRequiredMonth = subMonths(currentMonth, 5);
     const subNSFW: Record<string, boolean> = {};
-    // Filter to just the last 6 months.
-    posts = posts.filter(post => post.createdAt > subMonths(new Date(), 6));
-    for (let month = new Date().getMonth() - 5; month <= new Date().getMonth(); month++) {
-        const postsInMonth = posts.filter(post => post.createdAt.getMonth() === month);
+
+    // Check the current calendar month and the previous five calendar months.
+    posts = posts.filter(post => post.createdAt >= firstRequiredMonth);
+    for (let monthOffset = 5; monthOffset >= 0; monthOffset--) {
+        const requiredMonth = subMonths(currentMonth, monthOffset);
+        const postsInMonth = posts.filter(post => isSameMonth(post.createdAt, requiredMonth));
         if (postsInMonth.length === 0) {
             return false;
         }
@@ -314,15 +318,19 @@ export async function userHasContinuousNSFWHistory (username: string, context: T
             continue;
         }
 
+        let hasNSFWSubreddit = false;
         for (const subreddit of _.uniq(postsInMonth.map(post => post.subredditName))) {
             subNSFW[subreddit] ??= await subIsNSFW(subreddit, context);
             if (subNSFW[subreddit]) {
-                continue;
+                hasNSFWSubreddit = true;
+                break;
             }
         }
 
         // If we have a month with no NSFW posts and no NSFW subreddits, return false.
-        return false;
+        if (!hasNSFWSubreddit) {
+            return false;
+        }
     }
 
     return true;

--- a/src/modmail/autoAppealHandling.test.ts
+++ b/src/modmail/autoAppealHandling.test.ts
@@ -1,0 +1,13 @@
+import { appealConfigNeedsUserHistory } from "./autoAppealHandling.js";
+
+test("appeal config loads history when repeated comments are required", () => {
+    expect(appealConfigNeedsUserHistory([{ hasMoreThanOneCommentOnPost: true }])).toBe(true);
+});
+
+test("appeal config loads history when repeated comments are disallowed", () => {
+    expect(appealConfigNeedsUserHistory([{ hasMoreThanOneCommentOnPost: false }])).toBe(true);
+});
+
+test("appeal config skips history when no rule inspects repeated comments", () => {
+    expect(appealConfigNeedsUserHistory([{}])).toBe(false);
+});

--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -298,6 +298,10 @@ async function getAppealConfig (context: TriggerContext): Promise<AppealConfig[]
     return JSON.parse(configData) as AppealConfig[];
 }
 
+export function appealConfigNeedsUserHistory (appealConfig: { hasMoreThanOneCommentOnPost?: boolean }[]): boolean {
+    return appealConfig.some(config => config.hasMoreThanOneCommentOnPost !== undefined);
+}
+
 function formatPlaceholders (input: string, userDetails: UserDetails): string {
     let output = input;
     let dateFormat: string;
@@ -364,7 +368,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
 
     let history: (Post | Comment)[] = [];
 
-    if (appealConfig.some(config => config.hasMoreThanOneCommentOnPost)) {
+    if (appealConfigNeedsUserHistory(appealConfig)) {
         history = await context.reddit.getCommentsAndPostsByUser({
             username,
             limit: 100,


### PR DESCRIPTION
## Summary

Fixes automatic-review safeguards that could otherwise evaluate account history incorrectly or skip required history retrieval.

## Changes

- Treats the continuous-NSFW-history safeguard as six calendar months: the current calendar month plus the previous five calendar months.
- Handles the six-month window correctly across year boundaries and on the first day of a month.
- Counts activity in an NSFW subreddit as qualifying NSFW activity even when the individual post is not marked NSFW.
- Requires qualifying activity in every month of the configured six-month window.
- Loads account history whenever `hasMoreThanOneCommentOnPost` is configured, including when it is set to `false`.

## Impact

These corrections reduce the risk that an account is handled automatically when the configured safeguard should instead route it to moderator review.

## Validation

```powershell
npm.cmd exec -- eslint .
npm.cmd test
```

Regression tests cover:

- A six-month window across a year boundary.
- Execution on the first day of a month.
- NSFW-subreddit activity supplied indirectly through subreddit metadata.
- Missing qualifying activity in one month.
- A month containing only SFW activity.
- Both `true` and `false` values of `hasMoreThanOneCommentOnPost`.
