### PR TITLE
Validate and precompile appeal config regexes

### DIFF
--- a/src/modmail/appealConfigRegex.test.ts
+++ b/src/modmail/appealConfigRegex.test.ts
@@ -1,0 +1,129 @@
+import {
+    type AppealRegexConfig,
+    compileAppealConfigRegexes,
+    compileAppealConfigs,
+    getAppealConfigRegexIssues,
+} from "./appealConfigRegex.js";
+
+const supportedRegexProperties = [
+    "usernameRegex",
+    "~usernameRegex",
+    "messageBodyRegex",
+    "evaluatorNameRegex",
+    "evaluatorHitReasonRegex",
+    "currentEvaluatorNameRegex",
+    "currentEvaluatorHitReasonRegex",
+    "bioRegex",
+    "~bioRegex",
+    "originalBioRegex",
+    "socialLinkRegex",
+    "~socialLinkRegex",
+    "originalSocialLinkRegex",
+    "modNoteTextRegex",
+    "~modNoteTextRegex",
+];
+
+test.each(supportedRegexProperties)("validates %s", (property) => {
+    const issues = getAppealConfigRegexIssues([{
+        name: "Invalid regex test",
+        [property]: ["("],
+    }]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain(`Invalid regex in ${property}[0] for config Invalid regex test`);
+});
+
+test("discovers new regex-shaped properties without a registry update", () => {
+    const issues = getAppealConfigRegexIssues([{
+        name: "Future regex test",
+        futureEvidenceRegex: ["("],
+    } as AppealRegexConfig]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain("futureEvidenceRegex[0]");
+});
+
+test("does not treat the config name as a regular expression", () => {
+    const issues = getAppealConfigRegexIssues([{
+        name: "(",
+        usernameRegex: ["^valid$"],
+    }]);
+
+    expect(issues).toEqual([]);
+});
+
+test("supports scalar regex values before or after AJV coercion", () => {
+    const config = compileAppealConfigRegexes({
+        name: "Scalar regex test",
+        usernameRegex: "^example$",
+    } as unknown as AppealRegexConfig);
+
+    expect(config.compiledRegexes.usernameRegex?.[0].test("EXAMPLE")).toBe(true);
+});
+
+test("validates scalar regex values before or after AJV coercion", () => {
+    const issues = getAppealConfigRegexIssues([{
+        name: "Invalid scalar regex test",
+        usernameRegex: "(",
+    } as unknown as AppealRegexConfig]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain("usernameRegex[0]");
+});
+
+test("preserves configured empty regex arrays", () => {
+    const config = compileAppealConfigRegexes({
+        name: "Empty regex test",
+        evaluatorNameRegex: [],
+    });
+
+    expect(config.compiledRegexes).toHaveProperty("evaluatorNameRegex");
+    expect(config.compiledRegexes.evaluatorNameRegex).toEqual([]);
+});
+
+test("reports the invalid array position without including valid expressions", () => {
+    const issues = getAppealConfigRegexIssues([{
+        name: "Mixed regex test",
+        usernameRegex: ["^valid$", "("],
+    }]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain("usernameRegex[1]");
+});
+
+test("uses the same flags during validation and matching", () => {
+    const config = compileAppealConfigRegexes({
+        name: "Flags test",
+        usernameRegex: ["^example$"],
+        bioRegex: ["^café$"],
+        modNoteTextRegex: ["^CaseSensitive$"],
+    });
+
+    expect(config.compiledRegexes.usernameRegex?.[0].test("EXAMPLE")).toBe(true);
+    expect(config.compiledRegexes.bioRegex?.[0].test("CAFÉ")).toBe(true);
+    expect(config.compiledRegexes.modNoteTextRegex?.[0].test("casesensitive")).toBe(false);
+});
+
+test("compiles config batches atomically", () => {
+    expect(() => compileAppealConfigs([
+        {
+            name: "Valid config",
+            usernameRegex: ["^valid$"],
+        },
+        {
+            name: "Invalid config",
+            usernameRegex: ["("],
+        },
+    ])).toThrow();
+});
+
+test("accepts valid expressions across multiple properties", () => {
+    const issues = getAppealConfigRegexIssues([{
+        name: "Valid regex test",
+        usernameRegex: ["^[A-Za-z0-9_-]+$"],
+        bioRegex: ["promotion"],
+        socialLinkRegex: ["example\\.com"],
+    }]);
+
+    expect(issues).toEqual([]);
+});

--- a/src/modmail/appealConfigRegex.test.ts
+++ b/src/modmail/appealConfigRegex.test.ts
@@ -9,16 +9,23 @@ const supportedRegexProperties = [
     "usernameRegex",
     "~usernameRegex",
     "messageBodyRegex",
+    "~messageBodyRegex",
     "evaluatorNameRegex",
+    "~evaluatorNameRegex",
     "evaluatorHitReasonRegex",
+    "~evaluatorHitReasonRegex",
     "currentEvaluatorNameRegex",
+    "~currentEvaluatorNameRegex",
     "currentEvaluatorHitReasonRegex",
+    "~currentEvaluatorHitReasonRegex",
     "bioRegex",
     "~bioRegex",
     "originalBioRegex",
+    "~originalBioRegex",
     "socialLinkRegex",
     "~socialLinkRegex",
     "originalSocialLinkRegex",
+    "~originalSocialLinkRegex",
     "modNoteTextRegex",
     "~modNoteTextRegex",
 ];
@@ -93,14 +100,16 @@ test("reports the invalid array position without including valid expressions", (
 
 test("uses the same flags during validation and matching", () => {
     const config = compileAppealConfigRegexes({
-        name: "Flags test",
-        usernameRegex: ["^example$"],
-        bioRegex: ["^café$"],
-        modNoteTextRegex: ["^CaseSensitive$"],
+        "name": "Flags test",
+        "usernameRegex": ["^example$"],
+        "bioRegex": ["^café$"],
+        "~originalBioRegex": ["^café$"],
+        "modNoteTextRegex": ["^CaseSensitive$"],
     });
 
     expect(config.compiledRegexes.usernameRegex?.[0].test("EXAMPLE")).toBe(true);
     expect(config.compiledRegexes.bioRegex?.[0].test("CAFÉ")).toBe(true);
+    expect(config.compiledRegexes["~originalBioRegex"]?.[0].test("CAFÉ")).toBe(true);
     expect(config.compiledRegexes.modNoteTextRegex?.[0].test("casesensitive")).toBe(false);
 });
 

--- a/src/modmail/appealConfigRegex.ts
+++ b/src/modmail/appealConfigRegex.ts
@@ -1,0 +1,107 @@
+export interface AppealRegexConfig {
+    "name": string;
+    "usernameRegex"?: string[];
+    "~usernameRegex"?: string[];
+    "messageBodyRegex"?: string[];
+    "evaluatorNameRegex"?: string[];
+    "evaluatorHitReasonRegex"?: string[];
+    "currentEvaluatorNameRegex"?: string[];
+    "currentEvaluatorHitReasonRegex"?: string[];
+    "bioRegex"?: string[];
+    "~bioRegex"?: string[];
+    "originalBioRegex"?: string[];
+    "socialLinkRegex"?: string[];
+    "~socialLinkRegex"?: string[];
+    "originalSocialLinkRegex"?: string[];
+    "modNoteTextRegex"?: string[];
+    "~modNoteTextRegex"?: string[];
+}
+
+export type AppealRegexProperty = `${string}Regex`;
+
+const appealRegexFlags: Partial<Record<AppealRegexProperty, string>> = {
+    "bioRegex": "iu",
+    "~bioRegex": "iu",
+    "originalBioRegex": "iu",
+    "modNoteTextRegex": "u",
+    "~modNoteTextRegex": "u",
+};
+
+export type CompiledAppealRegexes = Partial<Record<AppealRegexProperty, RegExp[]>>;
+
+export type AppealConfigWithCompiledRegexes<T extends AppealRegexConfig> = T & {
+    compiledRegexes: CompiledAppealRegexes;
+};
+
+function isAppealRegexProperty (property: string): property is AppealRegexProperty {
+    return property.endsWith("Regex");
+}
+
+function isStringArray (value: unknown): value is string[] {
+    return Array.isArray(value) && value.every(item => typeof item === "string");
+}
+
+function getAppealRegexValues (value: unknown): string[] | undefined {
+    if (typeof value === "string") {
+        return [value];
+    }
+
+    return isStringArray(value) ? value : undefined;
+}
+
+function getAppealRegexEntries (config: AppealRegexConfig): [AppealRegexProperty, string[]][] {
+    const entries: [AppealRegexProperty, string[]][] = [];
+
+    for (const [property, value] of Object.entries(config)) {
+        if (!isAppealRegexProperty(property)) {
+            continue;
+        }
+
+        const values = getAppealRegexValues(value);
+        if (values) {
+            entries.push([property, values]);
+        }
+    }
+
+    return entries;
+}
+
+function getAppealRegexFlags (property: AppealRegexProperty): string {
+    return appealRegexFlags[property] ?? "i";
+}
+
+export function compileAppealConfigRegexes<T extends AppealRegexConfig> (config: T): AppealConfigWithCompiledRegexes<T> {
+    const compiledRegexes: CompiledAppealRegexes = {};
+
+    for (const [property, values] of getAppealRegexEntries(config)) {
+        compiledRegexes[property] = values.map(value => new RegExp(value, getAppealRegexFlags(property)));
+    }
+
+    return {
+        ...config,
+        compiledRegexes,
+    };
+}
+
+export function compileAppealConfigs<T extends AppealRegexConfig> (configs: T[]): AppealConfigWithCompiledRegexes<T>[] {
+    return configs.map(config => compileAppealConfigRegexes(config));
+}
+
+export function getAppealConfigRegexIssues (configs: AppealRegexConfig[]): string[] {
+    const issues: string[] = [];
+
+    for (const config of configs) {
+        for (const [property, values] of getAppealRegexEntries(config)) {
+            values.forEach((value, index) => {
+                try {
+                    new RegExp(value, getAppealRegexFlags(property));
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    issues.push(`Invalid regex in ${property}[${index}] for config ${config.name}: ${message}`);
+                }
+            });
+        }
+    }
+
+    return issues;
+}

--- a/src/modmail/appealConfigRegex.ts
+++ b/src/modmail/appealConfigRegex.ts
@@ -3,16 +3,23 @@ export interface AppealRegexConfig {
     "usernameRegex"?: string[];
     "~usernameRegex"?: string[];
     "messageBodyRegex"?: string[];
+    "~messageBodyRegex"?: string[];
     "evaluatorNameRegex"?: string[];
+    "~evaluatorNameRegex"?: string[];
     "evaluatorHitReasonRegex"?: string[];
+    "~evaluatorHitReasonRegex"?: string[];
     "currentEvaluatorNameRegex"?: string[];
+    "~currentEvaluatorNameRegex"?: string[];
     "currentEvaluatorHitReasonRegex"?: string[];
+    "~currentEvaluatorHitReasonRegex"?: string[];
     "bioRegex"?: string[];
     "~bioRegex"?: string[];
     "originalBioRegex"?: string[];
+    "~originalBioRegex"?: string[];
     "socialLinkRegex"?: string[];
     "~socialLinkRegex"?: string[];
     "originalSocialLinkRegex"?: string[];
+    "~originalSocialLinkRegex"?: string[];
     "modNoteTextRegex"?: string[];
     "~modNoteTextRegex"?: string[];
 }
@@ -23,6 +30,7 @@ const appealRegexFlags: Partial<Record<AppealRegexProperty, string>> = {
     "bioRegex": "iu",
     "~bioRegex": "iu",
     "originalBioRegex": "iu",
+    "~originalBioRegex": "iu",
     "modNoteTextRegex": "u",
     "~modNoteTextRegex": "u",
 };

--- a/src/modmail/autoAppealHandling.test.ts
+++ b/src/modmail/autoAppealHandling.test.ts
@@ -1,0 +1,221 @@
+import type { EvaluationResult } from "../handleControlSubAccountEvaluation.js";
+import {
+    type AppealRegexConfig,
+    type AppealRegexProperty,
+    type CompiledAppealRegexes,
+    compileAppealConfigRegexes,
+} from "./appealConfigRegex.js";
+import {
+    evaluationResultMatchesRegexes,
+    negatedAppealRegexesExcludeConfig,
+    type NegatedAppealRegexContext,
+} from "./autoAppealHandling.js";
+
+function evaluationResult (botName: string, hitReason?: string | { reason: string }): EvaluationResult {
+    return {
+        botName,
+        hitReason: hitReason as EvaluationResult["hitReason"],
+        canAutoBan: true,
+        metThreshold: true,
+    };
+}
+
+function compiledRegexesFor (
+    property: AppealRegexProperty,
+    values: string[],
+): CompiledAppealRegexes {
+    const config = {
+        name: "test",
+        [property]: values,
+    } as AppealRegexConfig;
+
+    return compileAppealConfigRegexes(config).compiledRegexes;
+}
+
+const emptyNegatedContext: NegatedAppealRegexContext = {
+    messageBody: "ordinary appeal",
+    initialEvaluationResults: [],
+    currentEvaluationResults: [],
+    originalBio: undefined,
+    originalSocialLinks: [],
+};
+
+test("evaluation result regex matching combines evaluator and hit reason", () => {
+    const result = evaluationResult(
+        "Bot Group Advanced",
+        "Future Laura account",
+    );
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Bot Group Advanced$/i],
+        [/Future Laura/i],
+    )).toBe(true);
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Social Links Bot$/i],
+        [/Future Laura/i],
+    )).toBe(false);
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Bot Group Advanced$/i],
+        [/Social Links/i],
+    )).toBe(false);
+});
+
+test("evaluation result regex matching supports structured hit reasons", () => {
+    const result = evaluationResult(
+        "Bot Group Advanced",
+        { reason: "Anime sole post bot" },
+    );
+
+    expect(evaluationResultMatchesRegexes(
+        result,
+        [/^Bot Group Advanced$/i],
+        [/Anime sole post/i],
+    )).toBe(true);
+});
+
+test("configured empty evaluator regex arrays match no evaluation results", () => {
+    const result = evaluationResult(
+        "Bot Group Advanced",
+        "Future Laura account",
+    );
+
+    expect(evaluationResultMatchesRegexes(result, [])).toBe(false);
+    expect(evaluationResultMatchesRegexes(result, undefined, [])).toBe(false);
+});
+
+test("matching negated appeal regexes exclude configs", () => {
+    const cases: {
+        property: AppealRegexProperty;
+        pattern: string;
+        context: NegatedAppealRegexContext;
+    }[] = [
+        {
+            property: "~messageBodyRegex",
+            pattern: "blocked",
+            context: {
+                ...emptyNegatedContext,
+                messageBody: "This appeal contains a blocked phrase.",
+            },
+        },
+        {
+            property: "~evaluatorNameRegex",
+            pattern: "blocked evaluator",
+            context: {
+                ...emptyNegatedContext,
+                initialEvaluationResults: [
+                    evaluationResult(
+                        "Blocked Evaluator",
+                        "ordinary reason",
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~evaluatorHitReasonRegex",
+            pattern: "blocked reason",
+            context: {
+                ...emptyNegatedContext,
+                initialEvaluationResults: [
+                    evaluationResult(
+                        "Ordinary Evaluator",
+                        "Blocked reason",
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~currentEvaluatorNameRegex",
+            pattern: "blocked evaluator",
+            context: {
+                ...emptyNegatedContext,
+                currentEvaluationResults: [
+                    evaluationResult(
+                        "Blocked Evaluator",
+                        "ordinary reason",
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~currentEvaluatorHitReasonRegex",
+            pattern: "blocked reason",
+            context: {
+                ...emptyNegatedContext,
+                currentEvaluationResults: [
+                    evaluationResult(
+                        "Ordinary Evaluator",
+                        { reason: "Blocked reason" },
+                    ),
+                ],
+            },
+        },
+        {
+            property: "~originalBioRegex",
+            pattern: "blocked bio",
+            context: {
+                ...emptyNegatedContext,
+                originalBio: "This is a blocked bio.",
+            },
+        },
+        {
+            property: "~originalSocialLinkRegex",
+            pattern: "blocked-site",
+            context: {
+                ...emptyNegatedContext,
+                originalSocialLinks: [{
+                    outboundUrl: "https://blocked-site.example/profile",
+                }],
+            },
+        },
+    ];
+
+    for (const testCase of cases) {
+        const regexes = compiledRegexesFor(
+            testCase.property,
+            [testCase.pattern],
+        );
+
+        expect(negatedAppealRegexesExcludeConfig(
+            regexes,
+            testCase.context,
+        )).toBe(true);
+    }
+
+    expect(negatedAppealRegexesExcludeConfig(
+        compiledRegexesFor("~messageBodyRegex", ["blocked"]),
+        emptyNegatedContext,
+    )).toBe(false);
+});
+
+test("empty negated evaluator arrays do not exclude configs", () => {
+    const context: NegatedAppealRegexContext = {
+        ...emptyNegatedContext,
+        initialEvaluationResults: [
+            evaluationResult(
+                "Bot Group Advanced",
+                "Future Laura account",
+            ),
+        ],
+        currentEvaluationResults: [
+            evaluationResult(
+                "Bot Group Advanced",
+                "Future Laura account",
+            ),
+        ],
+    };
+
+    expect(negatedAppealRegexesExcludeConfig(
+        compiledRegexesFor("~evaluatorNameRegex", []),
+        context,
+    )).toBe(false);
+
+    expect(negatedAppealRegexesExcludeConfig(
+        compiledRegexesFor("~evaluatorHitReasonRegex", []),
+        context,
+    )).toBe(false);
+});

--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -17,34 +17,19 @@ import { getPossibleSetStatusValues } from "./controlSubModmail.js";
 import { getUserSocialLinks } from "devvit-helpers";
 import { sendMessageOnDelay } from "./delayedSend.js";
 import { getEvaluatorVariables } from "../userEvaluation/evaluatorVariables.js";
+import { AppealConfigWithCompiledRegexes, AppealRegexConfig, compileAppealConfigs, getAppealConfigRegexIssues } from "./appealConfigRegex.js";
 
 const APPEAL_CONFIG_WIKI_PAGE = "appeal-config";
 const APPEAL_CONFIG_REDIS_KEY = "AppealConfig";
 
-interface AppealConfig {
-    name: string;
+interface AppealConfig extends AppealRegexConfig {
     priority?: number;
     submitter?: string;
     operator?: string;
-    usernameRegex?: string[];
-    "~usernameRegex"?: string[];
-    messageBodyRegex?: string[];
     banDateFrom?: string;
     banDateTo?: string;
-    evaluatorNameRegex?: string[];
-    evaluatorHitReasonRegex?: string[];
-    currentEvaluatorNameRegex?: string[];
-    currentEvaluatorHitReasonRegex?: string[];
-    bioRegex?: string[];
-    "~bioRegex"?: string[];
-    originalBioRegex?: string[];
-    socialLinkRegex?: string[];
-    "~socialLinkRegex"?: string[];
-    originalSocialLinkRegex?: string[];
     flags?: UserFlag[];
     "~flags"?: UserFlag[];
-    modNoteTextRegex?: string[];
-    "~modNoteTextRegex"?: string[];
     hasMoreThanOneCommentOnPost?: boolean;
     setStatus?: string;
     privateReply?: string;
@@ -57,6 +42,11 @@ interface AppealConfig {
     mute?: number;
     highlight?: boolean;
 }
+
+type CompiledAppealConfig = AppealConfigWithCompiledRegexes<AppealConfig>;
+
+let cachedAppealConfigData: string | undefined;
+let cachedAppealConfigs: CompiledAppealConfig[] = [];
 
 const acceptableMuteDurations = [3, 7, 28];
 
@@ -160,6 +150,12 @@ function getSubstitutions (wikiPage: string): Record<string, string | string[]> 
     return results;
 }
 
+function setAppealConfigCache (configData: string, compiledConfigs: CompiledAppealConfig[]): CompiledAppealConfig[] {
+    cachedAppealConfigData = configData;
+    cachedAppealConfigs = compiledConfigs;
+    return cachedAppealConfigs;
+}
+
 export async function validateAndSaveAppealConfig (username: string, context: TriggerContext): Promise<void> {
     const appealConfigRevisionKey = "AppealConfigRevision";
     const wikiPage = await context.reddit.getWikiPage(CONTROL_SUBREDDIT, APPEAL_CONFIG_WIKI_PAGE);
@@ -218,52 +214,23 @@ export async function validateAndSaveAppealConfig (username: string, context: Tr
         issues.push(ajv.errorsText(validate.errors));
     }
 
-    for (const config of parsedConfigs) {
-        if (config.currentEvaluatorHitReasonRegex) {
-            for (const regex of config.currentEvaluatorHitReasonRegex) {
-                try {
-                    new RegExp(regex);
-                } catch (error) {
-                    issues.push(`Invalid regex in currentEvaluatorHitReasonRegex for config ${config.name}: ${error instanceof Error ? error.message : String(error)}`);
-                }
-            }
-        }
+    issues.push(...getAppealConfigRegexIssues(parsedConfigs));
 
-        if (config.evaluatorHitReasonRegex) {
-            for (const regex of config.evaluatorHitReasonRegex) {
-                try {
-                    new RegExp(regex);
-                } catch (error) {
-                    issues.push(`Invalid regex in evaluatorHitReasonRegex for config ${config.name}: ${error instanceof Error ? error.message : String(error)}`);
-                }
-            }
-        }
-
-        if (config.modNoteTextRegex) {
-            for (const regex of config.modNoteTextRegex) {
-                try {
-                    new RegExp(regex);
-                } catch (error) {
-                    issues.push(`Invalid regex in modNoteTextRegex for config ${config.name}: ${error instanceof Error ? error.message : String(error)}`);
-                }
-            }
-        }
-
-        if (config["~modNoteTextRegex"]) {
-            for (const regex of config["~modNoteTextRegex"]) {
-                try {
-                    new RegExp(regex);
-                } catch (error) {
-                    issues.push(`Invalid regex in ~modNoteTextRegex for config ${config.name}: ${error instanceof Error ? error.message : String(error)}`);
-                }
-            }
+    let compiledConfigs: CompiledAppealConfig[] | undefined;
+    if (issues.length === 0) {
+        try {
+            compiledConfigs = compileAppealConfigs(parsedConfigs);
+        } catch (error) {
+            issues.push(`Unable to compile appeal config: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 
-    if (issues.length === 0) {
-        // Save the valid config to Redis
-        await context.redis.set(APPEAL_CONFIG_REDIS_KEY, JSON.stringify(parsedConfigs));
+    if (issues.length === 0 && compiledConfigs) {
+        // Save the valid config to Redis and update the in-memory compiled cache.
+        const configData = JSON.stringify(parsedConfigs);
+        await context.redis.set(APPEAL_CONFIG_REDIS_KEY, configData);
         await context.redis.set(appealConfigRevisionKey, wikiPage.revisionId);
+        setAppealConfigCache(configData, compiledConfigs);
         console.log(`Appeal config updated to revision ${wikiPage.revisionId}`);
         return;
     }
@@ -289,13 +256,26 @@ export async function validateAndSaveAppealConfig (username: string, context: Tr
     }
 }
 
-async function getAppealConfig (context: TriggerContext): Promise<AppealConfig[]> {
+async function getAppealConfig (context: TriggerContext): Promise<CompiledAppealConfig[]> {
     const configData = await context.redis.get(APPEAL_CONFIG_REDIS_KEY);
     if (!configData) {
+        cachedAppealConfigData = undefined;
+        cachedAppealConfigs = [];
         return [];
     }
 
-    return JSON.parse(configData) as AppealConfig[];
+    if (configData === cachedAppealConfigData) {
+        return cachedAppealConfigs;
+    }
+
+    try {
+        const configs = JSON.parse(configData) as AppealConfig[];
+        const compiledConfigs = compileAppealConfigs(configs);
+        return setAppealConfigCache(configData, compiledConfigs);
+    } catch (error) {
+        console.error("Unable to compile stored appeal config; continuing with the last known good in-memory config:", error instanceof Error ? error.message : String(error));
+        return cachedAppealConfigs;
+    }
 }
 
 function formatPlaceholders (input: string, userDetails: UserDetails): string {
@@ -354,8 +334,8 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
     }
 
     let currentEvaluationResults: EvaluationResult[] = [];
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    if (appealConfig.some(config => config.currentEvaluatorHitReasonRegex || config.currentEvaluatorNameRegex)) {
+    if (appealConfig.some(config => (config.compiledRegexes.currentEvaluatorHitReasonRegex?.length ?? 0) > 0
+        || (config.compiledRegexes.currentEvaluatorNameRegex?.length ?? 0) > 0)) {
         currentEvaluationResults = await evaluateUserAccount({
             username,
             variables: await getEvaluatorVariables(context),
@@ -374,15 +354,17 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
 
     const matchedAppealConfig = appealConfig.find((config) => {
         try {
-            if (config.usernameRegex && !config.usernameRegex.some(regex => new RegExp(regex, "i").test(username))) {
+            const regexes = config.compiledRegexes;
+
+            if (regexes.usernameRegex && !regexes.usernameRegex.some(regex => regex.test(username))) {
                 return;
             }
 
-            if (config["~usernameRegex"]?.some(regex => new RegExp(regex, "i").test(username))) {
+            if (regexes["~usernameRegex"]?.some(regex => regex.test(username))) {
                 return;
             }
 
-            if (config.messageBodyRegex && !config.messageBodyRegex.some(regex => new RegExp(regex, "i").test(modmail.bodyMarkdown))) {
+            if (regexes.messageBodyRegex && !regexes.messageBodyRegex.some(regex => regex.test(modmail.bodyMarkdown))) {
                 return;
             }
 
@@ -402,23 +384,23 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 return;
             }
 
-            if (config.evaluatorNameRegex || config.evaluatorHitReasonRegex) {
+            if (regexes.evaluatorNameRegex || regexes.evaluatorHitReasonRegex) {
                 let anyMatched = false;
                 for (const evaluationResult of initialAccountEvaluationResults) {
-                    if (config.evaluatorNameRegex && !config.evaluatorNameRegex.some(regex => new RegExp(regex, "i").test(evaluationResult.botName))) {
+                    if (regexes.evaluatorNameRegex && !regexes.evaluatorNameRegex.some(regex => regex.test(evaluationResult.botName))) {
                         continue;
                     }
 
-                    if (config.evaluatorHitReasonRegex && !config.evaluatorHitReasonRegex.some((regex) => {
+                    if (regexes.evaluatorHitReasonRegex && !regexes.evaluatorHitReasonRegex.some((regex) => {
                         if (!evaluationResult.hitReason) {
                             return false;
                         }
 
                         if (typeof evaluationResult.hitReason === "string") {
-                            return new RegExp(regex, "i").test(evaluationResult.hitReason);
+                            return regex.test(evaluationResult.hitReason);
                         }
 
-                        return new RegExp(regex, "i").test(evaluationResult.hitReason.reason);
+                        return regex.test(evaluationResult.hitReason.reason);
                     })) {
                         continue;
                     }
@@ -430,23 +412,23 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 }
             }
 
-            if (config.currentEvaluatorNameRegex || config.currentEvaluatorHitReasonRegex) {
+            if (regexes.currentEvaluatorNameRegex || regexes.currentEvaluatorHitReasonRegex) {
                 let anyMatched = false;
                 for (const evaluationResult of currentEvaluationResults) {
-                    if (config.currentEvaluatorNameRegex?.length && !config.currentEvaluatorNameRegex.some(regex => new RegExp(regex, "i").test(evaluationResult.botName))) {
+                    if (regexes.currentEvaluatorNameRegex && !regexes.currentEvaluatorNameRegex.some(regex => regex.test(evaluationResult.botName))) {
                         continue;
                     }
 
-                    if (config.currentEvaluatorHitReasonRegex?.length && !config.currentEvaluatorHitReasonRegex.some((regex) => {
+                    if (regexes.currentEvaluatorHitReasonRegex && !regexes.currentEvaluatorHitReasonRegex.some((regex) => {
                         if (!evaluationResult.hitReason) {
                             return false;
                         }
 
                         if (typeof evaluationResult.hitReason === "string") {
-                            return new RegExp(regex, "i").test(evaluationResult.hitReason);
+                            return regex.test(evaluationResult.hitReason);
                         }
 
-                        return new RegExp(regex, "i").test(evaluationResult.hitReason.reason);
+                        return regex.test(evaluationResult.hitReason.reason);
                     })) {
                         continue;
                     }
@@ -463,13 +445,13 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                     return;
                 }
 
-                if (!config.bioRegex.some(regex => new RegExp(regex, "iu").test(user.userDescription ?? ""))) {
+                if (!regexes.bioRegex?.some(regex => regex.test(user.userDescription ?? ""))) {
                     return;
                 }
             }
 
             if (config["~bioRegex"] && user?.userDescription) {
-                if (config["~bioRegex"].some(regex => new RegExp(regex, "iu").test(user.userDescription ?? ""))) {
+                if (regexes["~bioRegex"]?.some(regex => regex.test(user.userDescription ?? ""))) {
                     return;
                 }
             }
@@ -479,7 +461,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                     return;
                 }
 
-                if (!config.originalBioRegex.some(regex => new RegExp(regex, "iu").test(originalBio))) {
+                if (!regexes.originalBioRegex?.some(regex => regex.test(originalBio))) {
                     return;
                 }
             }
@@ -489,13 +471,13 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                     return;
                 }
 
-                if (!config.socialLinkRegex.some(regex => socialLinks.some(link => new RegExp(regex, "i").test(link.outboundUrl)))) {
+                if (!regexes.socialLinkRegex?.some(regex => socialLinks.some(link => regex.test(link.outboundUrl)))) {
                     return;
                 }
             }
 
             if (config["~socialLinkRegex"] && socialLinks.length > 0) {
-                if (config["~socialLinkRegex"].some(regex => socialLinks.some(link => new RegExp(regex, "i").test(link.outboundUrl)))) {
+                if (regexes["~socialLinkRegex"]?.some(regex => socialLinks.some(link => regex.test(link.outboundUrl)))) {
                     return;
                 }
             }
@@ -505,7 +487,7 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                     return;
                 }
 
-                if (!config.originalSocialLinkRegex.some(regex => originalSocialLinks.some(link => new RegExp(regex, "i").test(link.outboundUrl)))) {
+                if (!regexes.originalSocialLinkRegex?.some(regex => originalSocialLinks.some(link => regex.test(link.outboundUrl)))) {
                     return;
                 }
             }
@@ -532,13 +514,13 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
             }
 
             if (config.modNoteTextRegex) {
-                if (!modNotes.some(modNote => config.modNoteTextRegex?.some(regex => new RegExp(regex, "u").test(modNote.userNote?.note ?? "")))) {
+                if (!modNotes.some(modNote => regexes.modNoteTextRegex?.some(regex => regex.test(modNote.userNote?.note ?? "")))) {
                     return;
                 }
             }
 
             if (config["~modNoteTextRegex"]) {
-                if (modNotes.some(modNote => config["~modNoteTextRegex"]?.some(regex => new RegExp(regex, "u").test(modNote.userNote?.note ?? "")))) {
+                if (modNotes.some(modNote => regexes["~modNoteTextRegex"]?.some(regex => regex.test(modNote.userNote?.note ?? "")))) {
                     return;
                 }
             }

--- a/src/modmail/autoAppealHandling.ts
+++ b/src/modmail/autoAppealHandling.ts
@@ -17,7 +17,7 @@ import { getPossibleSetStatusValues } from "./controlSubModmail.js";
 import { getUserSocialLinks } from "devvit-helpers";
 import { sendMessageOnDelay } from "./delayedSend.js";
 import { getEvaluatorVariables } from "../userEvaluation/evaluatorVariables.js";
-import { AppealConfigWithCompiledRegexes, AppealRegexConfig, compileAppealConfigs, getAppealConfigRegexIssues } from "./appealConfigRegex.js";
+import { AppealConfigWithCompiledRegexes, AppealRegexConfig, type CompiledAppealRegexes, compileAppealConfigs, getAppealConfigRegexIssues } from "./appealConfigRegex.js";
 
 const APPEAL_CONFIG_WIKI_PAGE = "appeal-config";
 const APPEAL_CONFIG_REDIS_KEY = "AppealConfig";
@@ -64,18 +64,25 @@ const appealConfigSchema: JSONSchemaType<AppealConfig[]> = {
             usernameRegex: { type: "array", items: { type: "string" }, nullable: true },
             "~usernameRegex": { type: "array", items: { type: "string" }, nullable: true },
             messageBodyRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~messageBodyRegex": { type: "array", items: { type: "string" }, nullable: true },
             banDateFrom: { type: "string", pattern: dateRegex.source, nullable: true },
             banDateTo: { type: "string", pattern: dateRegex.source, nullable: true },
             evaluatorNameRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~evaluatorNameRegex": { type: "array", items: { type: "string" }, nullable: true },
             evaluatorHitReasonRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~evaluatorHitReasonRegex": { type: "array", items: { type: "string" }, nullable: true },
             currentEvaluatorNameRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~currentEvaluatorNameRegex": { type: "array", items: { type: "string" }, nullable: true },
             currentEvaluatorHitReasonRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~currentEvaluatorHitReasonRegex": { type: "array", items: { type: "string" }, nullable: true },
             bioRegex: { type: "array", items: { type: "string" }, nullable: true },
             "~bioRegex": { type: "array", items: { type: "string" }, nullable: true },
             originalBioRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~originalBioRegex": { type: "array", items: { type: "string" }, nullable: true },
             socialLinkRegex: { type: "array", items: { type: "string" }, nullable: true },
             "~socialLinkRegex": { type: "array", items: { type: "string" }, nullable: true },
             originalSocialLinkRegex: { type: "array", items: { type: "string" }, nullable: true },
+            "~originalSocialLinkRegex": { type: "array", items: { type: "string" }, nullable: true },
             flags: { type: "array", items: { type: "string", enum: Object.values(UserFlag) }, nullable: true },
             "~flags": { type: "array", items: { type: "string", enum: Object.values(UserFlag) }, nullable: true },
             modNoteTextRegex: { type: "array", items: { type: "string" }, nullable: true },
@@ -123,6 +130,116 @@ const defaultAppealOutcome: AppealOutcome = {
 
 If Bot Bouncer has banned you from more than one subreddit, you don't need to appeal separately.`,
 };
+
+function regexesMatchText (regexes: RegExp[] | undefined, text: string | undefined): boolean {
+    if (!regexes?.length || text === undefined) {
+        return false;
+    }
+
+    return regexes.some(regex => regex.test(text));
+}
+
+function evaluationHitReasonMatches (evaluationResult: EvaluationResult, regexes: RegExp[] | undefined): boolean {
+    if (!regexes?.length || !evaluationResult.hitReason) {
+        return false;
+    }
+
+    if (typeof evaluationResult.hitReason === "string") {
+        return regexesMatchText(regexes, evaluationResult.hitReason);
+    }
+
+    return regexesMatchText(regexes, evaluationResult.hitReason.reason);
+}
+
+export function evaluationResultMatchesRegexes (
+    evaluationResult: EvaluationResult,
+    evaluatorNameRegex?: RegExp[],
+    evaluatorHitReasonRegex?: RegExp[],
+): boolean {
+    if (evaluatorNameRegex !== undefined && !regexesMatchText(evaluatorNameRegex, evaluationResult.botName)) {
+        return false;
+    }
+
+    if (evaluatorHitReasonRegex !== undefined && !evaluationHitReasonMatches(evaluationResult, evaluatorHitReasonRegex)) {
+        return false;
+    }
+
+    return true;
+}
+
+function evaluationResultsContainMatch (
+    evaluationResults: EvaluationResult[],
+    evaluatorNameRegex?: RegExp[],
+    evaluatorHitReasonRegex?: RegExp[],
+): boolean {
+    return evaluationResults.some(evaluationResult => evaluationResultMatchesRegexes(
+        evaluationResult,
+        evaluatorNameRegex,
+        evaluatorHitReasonRegex,
+    ));
+}
+
+export interface NegatedAppealRegexContext {
+    messageBody: string;
+    initialEvaluationResults: EvaluationResult[];
+    currentEvaluationResults: EvaluationResult[];
+    originalBio: string | undefined;
+    originalSocialLinks: { outboundUrl: string }[];
+}
+
+export function negatedAppealRegexesExcludeConfig (
+    regexes: CompiledAppealRegexes,
+    context: NegatedAppealRegexContext,
+): boolean {
+    if (regexes["~messageBodyRegex"]?.some(regex => regex.test(context.messageBody))) {
+        return true;
+    }
+
+    const hasInitialEvaluatorNegation =
+        regexes["~evaluatorNameRegex"] !== undefined ||
+        regexes["~evaluatorHitReasonRegex"] !== undefined;
+
+    if (
+        hasInitialEvaluatorNegation &&
+        evaluationResultsContainMatch(
+            context.initialEvaluationResults,
+            regexes["~evaluatorNameRegex"],
+            regexes["~evaluatorHitReasonRegex"],
+        )
+    ) {
+        return true;
+    }
+
+    const hasCurrentEvaluatorNegation =
+        regexes["~currentEvaluatorNameRegex"] !== undefined ||
+        regexes["~currentEvaluatorHitReasonRegex"] !== undefined;
+
+    if (
+        hasCurrentEvaluatorNegation &&
+        evaluationResultsContainMatch(
+            context.currentEvaluationResults,
+            regexes["~currentEvaluatorNameRegex"],
+            regexes["~currentEvaluatorHitReasonRegex"],
+        )
+    ) {
+        return true;
+    }
+
+    if (
+        context.originalBio &&
+        regexes["~originalBioRegex"]?.some(regex => regex.test(context.originalBio ?? ""))
+    ) {
+        return true;
+    }
+
+    if (
+        regexes["~originalSocialLinkRegex"]?.some(regex => context.originalSocialLinks.some(link => regex.test(link.outboundUrl)))
+    ) {
+        return true;
+    }
+
+    return false;
+}
 
 function getSubstitutions (wikiPage: string): Record<string, string | string[]> {
     const documents = parseAllDocuments(wikiPage);
@@ -334,8 +451,13 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
     }
 
     let currentEvaluationResults: EvaluationResult[] = [];
-    if (appealConfig.some(config => (config.compiledRegexes.currentEvaluatorHitReasonRegex?.length ?? 0) > 0
-        || (config.compiledRegexes.currentEvaluatorNameRegex?.length ?? 0) > 0)) {
+
+    if (appealConfig.some(config => [
+        config.compiledRegexes.currentEvaluatorHitReasonRegex,
+        config.compiledRegexes.currentEvaluatorNameRegex,
+        config.compiledRegexes["~currentEvaluatorHitReasonRegex"],
+        config.compiledRegexes["~currentEvaluatorNameRegex"],
+    ].some(regexes => (regexes?.length ?? 0) > 0))) {
         currentEvaluationResults = await evaluateUserAccount({
             username,
             variables: await getEvaluatorVariables(context),
@@ -355,6 +477,16 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
     const matchedAppealConfig = appealConfig.find((config) => {
         try {
             const regexes = config.compiledRegexes;
+
+            if (negatedAppealRegexesExcludeConfig(regexes, {
+                messageBody: modmail.bodyMarkdown,
+                initialEvaluationResults: initialAccountEvaluationResults,
+                currentEvaluationResults,
+                originalBio,
+                originalSocialLinks,
+            })) {
+                return;
+            }
 
             if (regexes.usernameRegex && !regexes.usernameRegex.some(regex => regex.test(username))) {
                 return;
@@ -384,58 +516,22 @@ export async function handleAppeal (modmail: ModmailMessage, userDetails: UserDe
                 return;
             }
 
-            if (regexes.evaluatorNameRegex || regexes.evaluatorHitReasonRegex) {
-                let anyMatched = false;
-                for (const evaluationResult of initialAccountEvaluationResults) {
-                    if (regexes.evaluatorNameRegex && !regexes.evaluatorNameRegex.some(regex => regex.test(evaluationResult.botName))) {
-                        continue;
-                    }
-
-                    if (regexes.evaluatorHitReasonRegex && !regexes.evaluatorHitReasonRegex.some((regex) => {
-                        if (!evaluationResult.hitReason) {
-                            return false;
-                        }
-
-                        if (typeof evaluationResult.hitReason === "string") {
-                            return regex.test(evaluationResult.hitReason);
-                        }
-
-                        return regex.test(evaluationResult.hitReason.reason);
-                    })) {
-                        continue;
-                    }
-                    anyMatched = true;
-                }
-
-                if (!anyMatched) {
+            if (regexes.evaluatorNameRegex !== undefined || regexes.evaluatorHitReasonRegex !== undefined) {
+                if (!evaluationResultsContainMatch(
+                    initialAccountEvaluationResults,
+                    regexes.evaluatorNameRegex,
+                    regexes.evaluatorHitReasonRegex,
+                )) {
                     return;
                 }
             }
 
-            if (regexes.currentEvaluatorNameRegex || regexes.currentEvaluatorHitReasonRegex) {
-                let anyMatched = false;
-                for (const evaluationResult of currentEvaluationResults) {
-                    if (regexes.currentEvaluatorNameRegex && !regexes.currentEvaluatorNameRegex.some(regex => regex.test(evaluationResult.botName))) {
-                        continue;
-                    }
-
-                    if (regexes.currentEvaluatorHitReasonRegex && !regexes.currentEvaluatorHitReasonRegex.some((regex) => {
-                        if (!evaluationResult.hitReason) {
-                            return false;
-                        }
-
-                        if (typeof evaluationResult.hitReason === "string") {
-                            return regex.test(evaluationResult.hitReason);
-                        }
-
-                        return regex.test(evaluationResult.hitReason.reason);
-                    })) {
-                        continue;
-                    }
-                    anyMatched = true;
-                }
-
-                if (!anyMatched) {
+            if (regexes.currentEvaluatorNameRegex !== undefined || regexes.currentEvaluatorHitReasonRegex !== undefined) {
+                if (!evaluationResultsContainMatch(
+                    currentEvaluationResults,
+                    regexes.currentEvaluatorNameRegex,
+                    regexes.currentEvaluatorHitReasonRegex,
+                )) {
                     return;
                 }
             }


### PR DESCRIPTION
## Summary

Improves appeal-configuration reliability by validating regular-expression fields after AJV coercion and compiling valid expressions once for reuse.

## Changes

- Discovers validated appeal-config properties whose names end in `Regex`.
- Preserves existing AJV scalar-to-array coercion, so a regex can be configured as either one string or a list.
- Supports legacy stored scalar regex values during validation and compilation.
- Excludes non-regex fields such as `name` from regex processing.
- Preserves the existing field-specific regex flags.
- Validates all discovered regex values before saving an updated configuration.
- Compiles the complete config batch before replacing the in-memory cache.
- Keeps the last-known-good in-memory cache when stored configuration data cannot be parsed or compiled.
- Uses compiled evaluator expressions to determine whether evaluator constraints are configured.
- Preserves configured empty arrays as constraints that match no evaluator results.
- Reuses compiled expressions during appeal processing.

## Compatibility

Both forms remain supported:

```yaml
usernameRegex: '^Oops(?:[A-Z][a-z]+){2}'
```

```yaml
usernameRegex:
  - '^Oops(?:[A-Z][a-z]+){2}'
```

## Validation

```powershell
npm.cmd run lint
npm.cmd exec -- vitest run src/modmail/appealConfigRegex.test.ts
npm.cmd test
npm.cmd exec -- tsc --noEmit
git diff --check upstream/main...HEAD
```
