### PR TITLE
Improve appeal processing reliability

### DIFF
--- a/src/modmail/controlSubModmail.ts
+++ b/src/modmail/controlSubModmail.ts
@@ -24,6 +24,7 @@ import { getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
 import { generateOpenAISummary } from "../aiAnalysis/createAISummary.js";
 import { handleAskAI } from "../aiAnalysis/askAI.js";
 import pluralize from "pluralize";
+import { abandonConversationProcessing, beginConversationProcessing, completeConversationProcessing } from "./conversationProcessing.js";
 
 export function getPossibleSetStatusValues (): string[] {
     return _.uniq([...FLAIR_MAPPINGS.map(entry => entry.postFlair), ...Object.values(UserStatus)]);
@@ -199,14 +200,22 @@ export function markdownToText (markdown: json2md.DataObject[], limit = 5000): s
 }
 
 async function handleModmailFromUser (modmail: ModmailMessage, context: TriggerContext) {
-    const username = modmail.messageAuthor;
-
-    const conversationHandledKey = `conversationHandled~${modmail.conversationId}`;
-    if (await context.redis.exists(conversationHandledKey)) {
+    const processingToken = await beginConversationProcessing(modmail.conversationId, context);
+    if (!processingToken) {
         return;
     }
 
-    await context.redis.set(conversationHandledKey, "true", { expiration: addDays(new Date(), 28) });
+    try {
+        await processModmailFromUser(modmail, context);
+        await completeConversationProcessing(modmail.conversationId, processingToken, context);
+    } catch (error) {
+        await abandonConversationProcessing(modmail.conversationId, processingToken, context);
+        throw error;
+    }
+}
+
+async function processModmailFromUser (modmail: ModmailMessage, context: TriggerContext) {
+    const username = modmail.messageAuthor;
 
     if (username === INTERNAL_BOT || username.startsWith(context.appSlug)) {
         return;

--- a/src/modmail/conversationProcessing.test.ts
+++ b/src/modmail/conversationProcessing.test.ts
@@ -1,0 +1,73 @@
+import type { TriggerContext } from "@devvit/public-api";
+import {
+    abandonConversationProcessing,
+    beginConversationProcessing,
+    completeConversationProcessing,
+} from "./conversationProcessing.js";
+
+interface StoredValue {
+    value: string;
+}
+
+function createContext () {
+    const values = new Map<string, StoredValue>();
+
+    const context = {
+        redis: {
+            exists: (key: string) => Promise.resolve(values.has(key)),
+            get: (key: string) => Promise.resolve(values.get(key)?.value),
+            set: (key: string, value: string, options?: { nx?: boolean }) => {
+                if (!options?.nx || !values.has(key)) {
+                    values.set(key, { value });
+                }
+                return Promise.resolve();
+            },
+            del: (...keys: string[]) => {
+                for (const key of keys) {
+                    values.delete(key);
+                }
+                return Promise.resolve();
+            },
+        },
+    } as unknown as TriggerContext;
+
+    return { context, values };
+}
+
+test("conversation processing acquires one lock and rejects a competing worker", async () => {
+    const { context } = createContext();
+
+    const firstToken = await beginConversationProcessing("conversation-1", context);
+    const secondToken = await beginConversationProcessing("conversation-1", context);
+
+    expect(firstToken).toBeDefined();
+    expect(secondToken).toBeUndefined();
+});
+
+test("completed conversations are not processed again", async () => {
+    const { context, values } = createContext();
+
+    const token = await beginConversationProcessing("conversation-2", context);
+    if (!token) {
+        throw new Error("Expected the processing lock to be acquired.");
+    }
+
+    await completeConversationProcessing("conversation-2", token, context);
+
+    expect(values.has("conversationHandled~conversation-2")).toBe(true);
+    expect(values.has("conversationProcessing~conversation-2")).toBe(false);
+    await expect(beginConversationProcessing("conversation-2", context)).resolves.toBeUndefined();
+});
+
+test("failed processing releases its lock so the conversation can be retried", async () => {
+    const { context } = createContext();
+
+    const token = await beginConversationProcessing("conversation-3", context);
+    if (!token) {
+        throw new Error("Expected the processing lock to be acquired.");
+    }
+
+    await abandonConversationProcessing("conversation-3", token, context);
+
+    await expect(beginConversationProcessing("conversation-3", context)).resolves.toBeDefined();
+});

--- a/src/modmail/conversationProcessing.ts
+++ b/src/modmail/conversationProcessing.ts
@@ -1,0 +1,56 @@
+import type { TriggerContext } from "@devvit/public-api";
+import { addDays, addMinutes } from "date-fns";
+
+const CONVERSATION_PROCESSING_MINUTES = 10;
+const CONVERSATION_HANDLED_DAYS = 28;
+
+function getConversationHandledKey (conversationId: string): string {
+    return `conversationHandled~${conversationId}`;
+}
+
+function getConversationProcessingKey (conversationId: string): string {
+    return `conversationProcessing~${conversationId}`;
+}
+
+export async function beginConversationProcessing (conversationId: string, context: TriggerContext): Promise<string | undefined> {
+    if (await context.redis.exists(getConversationHandledKey(conversationId))) {
+        return;
+    }
+
+    const processingKey = getConversationProcessingKey(conversationId);
+    const token = `${Date.now()}:${Math.random()}`;
+    await context.redis.set(processingKey, token, {
+        nx: true,
+        expiration: addMinutes(new Date(), CONVERSATION_PROCESSING_MINUTES),
+    });
+
+    if (await context.redis.get(processingKey) !== token) {
+        return;
+    }
+
+    if (await context.redis.exists(getConversationHandledKey(conversationId))) {
+        await context.redis.del(processingKey);
+        return;
+    }
+
+    return token;
+}
+
+export async function completeConversationProcessing (conversationId: string, token: string, context: TriggerContext): Promise<void> {
+    const processingKey = getConversationProcessingKey(conversationId);
+    if (await context.redis.get(processingKey) !== token) {
+        return;
+    }
+
+    await context.redis.set(getConversationHandledKey(conversationId), "true", {
+        expiration: addDays(new Date(), CONVERSATION_HANDLED_DAYS),
+    });
+    await context.redis.del(processingKey);
+}
+
+export async function abandonConversationProcessing (conversationId: string, token: string, context: TriggerContext): Promise<void> {
+    const processingKey = getConversationProcessingKey(conversationId);
+    if (await context.redis.get(processingKey) === token) {
+        await context.redis.del(processingKey);
+    }
+}

--- a/src/modmail/delayedSend.test.ts
+++ b/src/modmail/delayedSend.test.ts
@@ -1,0 +1,113 @@
+import type { JobContext, JSONObject, ScheduledJobEvent } from "@devvit/public-api";
+import { ControlSubredditJob } from "../constants.js";
+import { processDelayedMessages } from "./delayedSend.js";
+
+interface QueueEntry {
+    member: string;
+    score: number;
+}
+
+function createContext (options?: { replyFails?: boolean; archiveFails?: boolean }) {
+    const queue: QueueEntry[] = [{
+        member: JSON.stringify({
+            id: "message-1",
+            conversationId: "conversation-1",
+            message: "Test reply",
+            sendAt: new Date(0),
+            archive: true,
+        }),
+        score: 0,
+    }];
+    const values = new Map<string, string>();
+    let replyCalls = 0;
+    let archiveCalls = 0;
+
+    const context = {
+        redis: {
+            exists: (key: string) => Promise.resolve(values.has(key)),
+            set: (key: string, value: string) => {
+                values.set(key, value);
+                return Promise.resolve();
+            },
+            del: (key: string) => {
+                values.delete(key);
+                return Promise.resolve();
+            },
+            zRange: () => Promise.resolve([...queue]),
+            zRem: (_key: string, members: string[]) => {
+                for (const member of members) {
+                    const index = queue.findIndex(entry => entry.member === member);
+                    if (index !== -1) {
+                        queue.splice(index, 1);
+                    }
+                }
+                return Promise.resolve();
+            },
+        },
+        reddit: {
+            modMail: {
+                reply: () => {
+                    replyCalls++;
+                    return options?.replyFails ? Promise.reject(new Error("reply failed")) : Promise.resolve();
+                },
+                archiveConversation: () => {
+                    archiveCalls++;
+                    return options?.archiveFails ? Promise.reject(new Error("archive failed")) : Promise.resolve();
+                },
+            },
+        },
+        scheduler: {
+            runJob: () => Promise.resolve(),
+        },
+    } as unknown as JobContext;
+
+    return {
+        context,
+        queue,
+        values,
+        getReplyCalls: () => replyCalls,
+        getArchiveCalls: () => archiveCalls,
+    };
+}
+
+const event = {
+    name: ControlSubredditJob.ProcessDelayedMessages,
+    data: { firstRun: false },
+} as ScheduledJobEvent<JSONObject | undefined>;
+
+test("a failed delayed reply remains queued for retry", async () => {
+    const state = createContext({ replyFails: true });
+
+    await expect(processDelayedMessages(event, state.context)).rejects.toThrow("reply failed");
+
+    expect(state.queue).toHaveLength(1);
+    expect(state.values.has("delayedMessageReplySent~message-1")).toBe(false);
+});
+
+test("a delivered delayed reply is removed only after delivery succeeds", async () => {
+    const state = createContext();
+
+    await processDelayedMessages(event, state.context);
+
+    expect(state.getReplyCalls()).toBe(1);
+    expect(state.getArchiveCalls()).toBe(1);
+    expect(state.queue).toHaveLength(0);
+    expect(state.values.has("delayedMessageReplySent~message-1")).toBe(true);
+});
+
+test("an archive failure retries the archive without sending a duplicate reply", async () => {
+    const state = createContext({ archiveFails: true });
+
+    await expect(processDelayedMessages(event, state.context)).rejects.toThrow("archive failed");
+    expect(state.queue).toHaveLength(1);
+    expect(state.getReplyCalls()).toBe(1);
+    expect(state.values.has("delayedMessageReplySent~message-1")).toBe(true);
+
+    const retryState = createContext();
+    retryState.values.set("delayedMessageReplySent~message-1", "sent");
+    await processDelayedMessages(event, retryState.context);
+
+    expect(retryState.getReplyCalls()).toBe(0);
+    expect(retryState.getArchiveCalls()).toBe(1);
+    expect(retryState.queue).toHaveLength(0);
+});

--- a/src/modmail/delayedSend.ts
+++ b/src/modmail/delayedSend.ts
@@ -1,9 +1,10 @@
 import { JobContext, JSONObject, ScheduledJobEvent, TriggerContext } from "@devvit/public-api";
-import { addMinutes, addSeconds } from "date-fns";
+import { addDays, addMinutes, addSeconds } from "date-fns";
 import json2md from "json2md";
 import { ControlSubredditJob } from "../constants.js";
 
 interface DelayedMessageOptions {
+    id?: string;
     conversationId: string;
     message: string;
     sendAt: Date;
@@ -11,6 +12,23 @@ interface DelayedMessageOptions {
 }
 
 const DELAYED_MESSAGE_QUEUE = "delayedMessageQueue";
+
+function createDelayedMessageId (conversationId: string): string {
+    return `${conversationId}:${Date.now()}:${Math.random()}`;
+}
+
+function getReplySentKey (messageId: string): string {
+    return `delayedMessageReplySent~${messageId}`;
+}
+
+function legacyMessageId (member: string): string {
+    let hash = 2166136261;
+    for (let index = 0; index < member.length; index++) {
+        hash ^= member.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+    return `legacy:${(hash >>> 0).toString(36)}`;
+}
 
 export async function sendMessageOnDelay (context: TriggerContext, params: DelayedMessageOptions) {
     if (params.sendAt <= addSeconds(new Date(), 10)) {
@@ -27,7 +45,11 @@ export async function sendMessageOnDelay (context: TriggerContext, params: Delay
         return;
     }
 
-    await context.redis.zAdd(DELAYED_MESSAGE_QUEUE, { member: JSON.stringify(params), score: params.sendAt.getTime() });
+    const queuedMessage: DelayedMessageOptions = {
+        ...params,
+        id: params.id ?? createDelayedMessageId(params.conversationId),
+    };
+    await context.redis.zAdd(DELAYED_MESSAGE_QUEUE, { member: JSON.stringify(queuedMessage), score: params.sendAt.getTime() });
 
     if (params.sendAt > addMinutes(new Date(), 1)) {
         const privateReplyMessage: json2md.DataObject[] = [
@@ -58,18 +80,24 @@ export async function processDelayedMessages (event: ScheduledJobEvent<JSONObjec
         return;
     }
 
-    const firstMessage = JSON.parse(queuedMessages[0].member) as DelayedMessageOptions;
-    await context.redis.zRem(DELAYED_MESSAGE_QUEUE, [queuedMessages[0].member]);
+    const queuedMember = queuedMessages[0].member;
+    const firstMessage = JSON.parse(queuedMember) as DelayedMessageOptions;
+    const replySentKey = getReplySentKey(firstMessage.id ?? legacyMessageId(queuedMember));
 
-    await context.reddit.modMail.reply({
-        conversationId: firstMessage.conversationId,
-        isAuthorHidden: true,
-        body: firstMessage.message,
-    });
+    if (!await context.redis.exists(replySentKey)) {
+        await context.reddit.modMail.reply({
+            conversationId: firstMessage.conversationId,
+            isAuthorHidden: true,
+            body: firstMessage.message,
+        });
+        await context.redis.set(replySentKey, Date.now().toString(), { expiration: addDays(new Date(), 28) });
+    }
 
     if (firstMessage.archive) {
         await context.reddit.modMail.archiveConversation(firstMessage.conversationId);
     }
+
+    await context.redis.zRem(DELAYED_MESSAGE_QUEUE, [queuedMember]);
 
     if (queuedMessages.length > 1) {
         await context.scheduler.runJob({


### PR DESCRIPTION
## Summary

Improves the reliability of appeal processing and delayed modmail delivery.

The existing workflow could mark a conversation as handled before processing completed, which meant a transient failure could suppress retries for up to 28 days. Delayed messages were also removed from the queue before Reddit confirmed that the reply and archive operations had succeeded.

## Changes

* Adds a short-lived processing lock to prevent concurrent handling of the same conversation.
* Writes the durable handled marker only after processing completes successfully.
* Releases the processing lock when handling fails so the conversation can be retried.
* Keeps delayed messages in the queue until delivery succeeds.
* Records successful reply delivery separately so an archive retry does not send the public reply again.
* Preserves compatibility with delayed messages already stored in the existing queue format.
* Adds regression tests covering processing locks, completion markers, retry behavior, delayed-message delivery, and duplicate-reply prevention.

## Impact

These changes reduce the risk that:

* an appeal is permanently skipped because of a temporary processing failure;
* a delayed reply is lost after a Reddit API error;
* a delayed reply is sent more than once when only the archive operation needs to be retried.

The patch does not change appeal-rule matching or automatic appeal outcomes.

## Validation

```powershell
npm.cmd exec -- tsc --noEmit
npm.cmd exec -- eslint .
npm.cmd test
```