### PR TITLE
Evaluator accuracy statistics reordering

### DIFF
--- a/src/statistics/evaluatorAccuracyStatistics.test.ts
+++ b/src/statistics/evaluatorAccuracyStatistics.test.ts
@@ -1,4 +1,4 @@
-﻿import { compareEvaluatorAccuracyEntries } from "./evaluatorAccuracyStatistics.js";
+import { compareEvaluatorAccuracyEntries } from "./evaluatorAccuracyStatistics.js";
 
 type AccuracyEntry = Parameters<typeof compareEvaluatorAccuracyEntries>[0];
 
@@ -41,4 +41,3 @@ test("sorts zero-hit and displayed zero-percent evaluators first, alphabetically
         "Bot Group Advanced~Zulu",
     ]);
 });
-

--- a/src/statistics/evaluatorAccuracyStatistics.test.ts
+++ b/src/statistics/evaluatorAccuracyStatistics.test.ts
@@ -1,0 +1,44 @@
+﻿import { compareEvaluatorAccuracyEntries } from "./evaluatorAccuracyStatistics.js";
+
+type AccuracyEntry = Parameters<typeof compareEvaluatorAccuracyEntries>[0];
+
+function makeAccuracyEntry (
+    key: string,
+    totalCount: number,
+    bannedCount: number,
+): AccuracyEntry {
+    return [
+        key,
+        {
+            totalCount,
+            bannedCount,
+            bannedAccounts: [],
+            unbannedAccounts: [],
+        },
+    ];
+}
+
+test("sorts zero-hit and displayed zero-percent evaluators first, alphabetically within each group", () => {
+    const entries: AccuracyEntry[] = [
+        makeAccuracyEntry("Bot Group Advanced~Zulu", 10, 5),
+        makeAccuracyEntry("Bot Group Advanced~Echo", 10, 1),
+        makeAccuracyEntry("Bot Group Advanced~Bravo", 10, 0),
+        makeAccuracyEntry("Bot Group Advanced~Alpha", 0, 0),
+        makeAccuracyEntry("Bot Group Advanced~Charlie", 200, 1),
+        makeAccuracyEntry("Bot Group Advanced~Delta", 10, 2),
+    ];
+
+    const sortedKeys = entries
+        .sort(compareEvaluatorAccuracyEntries)
+        .map(([key]) => key);
+
+    expect(sortedKeys).toEqual([
+        "Bot Group Advanced~Alpha",
+        "Bot Group Advanced~Bravo",
+        "Bot Group Advanced~Charlie",
+        "Bot Group Advanced~Delta",
+        "Bot Group Advanced~Echo",
+        "Bot Group Advanced~Zulu",
+    ]);
+});
+

--- a/src/statistics/evaluatorAccuracyStatistics.ts
+++ b/src/statistics/evaluatorAccuracyStatistics.ts
@@ -46,6 +46,28 @@ interface EvaluationAccuracyResult {
     lastSeen?: number;
 }
 
+function getEvaluatorAccuracyPercentage (data: EvaluationAccuracyResult): number | undefined {
+    if (data.totalCount === 0) {
+        return undefined;
+    }
+
+    return Math.floor((data.bannedCount / data.totalCount) * 100);
+}
+
+export function compareEvaluatorAccuracyEntries (
+    [keyA, dataA]: [string, EvaluationAccuracyResult],
+    [keyB, dataB]: [string, EvaluationAccuracyResult],
+): number {
+    const prioritizeA = dataA.totalCount === 0 || getEvaluatorAccuracyPercentage(dataA) === 0;
+    const prioritizeB = dataB.totalCount === 0 || getEvaluatorAccuracyPercentage(dataB) === 0;
+
+    if (prioritizeA !== prioritizeB) {
+        return prioritizeA ? -1 : 1;
+    }
+
+    return keyA.localeCompare(keyB);
+}
+
 function getEvaluationResultsKey (evaluationResult: EvaluationResult): string {
     if (evaluationResult.hitReason && evaluationResult.botName.includes("Bot Group")) {
         if (typeof evaluationResult.hitReason === "string") {
@@ -187,15 +209,16 @@ export async function buildEvaluatorAccuracyStatistics (event: ScheduledJobEvent
     const tableRows: string[][] = [];
     const headers: string[] = ["Bot Name", "Hit Reason", "Last Seen", "Total Count", "Banned Count", "Accuracy (%)", "Example Banned Accounts", "Unbanned Accounts"];
 
-    for (const [key, data] of _.toPairs(evaluatorAccuracyStats).sort((a, b) => a > b ? 1 : -1)) {
+    for (const [key, data] of _.toPairs(evaluatorAccuracyStats).sort(compareEvaluatorAccuracyEntries)) {
         const [botName, hitReason] = key.split("~");
+        const accuracyPercentage = getEvaluatorAccuracyPercentage(data);
         tableRows.push([
             botName,
             hitReason || "",
             data.lastSeen ? format(new Date(data.lastSeen), "yyyy-MM-dd") : "",
             data.totalCount.toLocaleString(),
             data.bannedCount.toLocaleString(),
-            data.totalCount ? `${Math.floor((data.bannedCount / data.totalCount) * 100)}%` : "",
+            accuracyPercentage !== undefined ? `${accuracyPercentage}%` : "",
             data.bannedAccounts.slice(-5).map(account => `/u/${account}`).join(", "),
             data.unbannedAccounts.map(account => `/u/${account}`).join(", "),
         ]);


### PR DESCRIPTION
Lists bot groups with zero hits or 0% accuracy at the top of the evaluator accuracy table, making those groups easier to review and remove.

## Tests

- `npm.cmd test -- src/statistics/evaluatorAccuracyStatistics.test.ts`
- `npm.cmd run lint`