### PR TITLE
Use resolved target for !setstatus overrides

### DIFF
--- a/src/modmail/controlSubModmail.ts
+++ b/src/modmail/controlSubModmail.ts
@@ -143,7 +143,7 @@ export async function handleControlSubredditModmail (modmail: ModmailMessage, co
 
             const username = await getOverrideForSetStatusCommand(modmail.conversationId, context) ?? modmail.participant;
 
-            const currentStatus = await getUserStatus(modmail.participant, context);
+            const currentStatus = await getUserStatus(username, context);
             if (currentStatus && isLinkId(currentStatus.trackingPostId) && currentStatus.userStatus !== newStatus) {
                 await context.redis.set(`userStatusOverrideValue~${username}`, modmail.messageAuthor, { expiration: addHours(new Date(), 2) });
 


### PR DESCRIPTION
Closes #503

## Summary

Uses the resolved `!setstatus` target when retrieving the account's existing status and tracking post.

## Problem

When a modmail override was present, the command resolved the intended username but continued to call `getUserStatus()` with the conversation participant.

This could cause the participant's tracking post to be updated while the attribution key and confirmation message referred to the override account.

## Change

The status lookup now uses the already-resolved target username. The no-override path remains unchanged because that value falls back to the conversation participant.

## Impact

The status lookup, tracking-post update, moderator attribution, and confirmation message now consistently refer to the same account.

## Validation

- `npm.cmd run lint`
- `npm.cmd test`
- `npm.cmd exec -- tsc --noEmit`
- `git diff --check`