### PR TITLE
Prevent duplicate account and OpenAI summaries

### DIFF
--- a/src/UserSummary/userSummary.ts
+++ b/src/UserSummary/userSummary.ts
@@ -1,6 +1,6 @@
 import { Comment, JSONValue, Post, TriggerContext } from "@devvit/public-api";
 import { median } from "../utility.js";
-import { addMilliseconds, differenceInDays, differenceInHours, differenceInMilliseconds, differenceInMinutes, differenceInSeconds, Duration, format, formatDuration, getYear, intervalToDuration, startOfDecade } from "date-fns";
+import { addDays, addMilliseconds, differenceInDays, differenceInHours, differenceInMilliseconds, differenceInMinutes, differenceInSeconds, Duration, format, formatDuration, getYear, intervalToDuration, startOfDecade } from "date-fns";
 import _ from "lodash";
 import { count } from "@wordpress/wordcount";
 import { isUserPotentiallyBlockingBot } from "./blockChecker.js";
@@ -17,6 +17,7 @@ import { getSubmitterSuccessRate } from "../statistics/submitterStatistics.js";
 import { getSummaryExtras } from "./summaryExtras.js";
 import { ALL_RELEVANT_EVALUTORS, CONTROL_SUBREDDIT } from "../constants.js";
 import { getAppealTextForUser } from "../modmail/appealStore.js";
+import { acquireIdempotencyLock, releaseIdempotencyLock } from "../idempotency.js";
 
 function formatDifferenceInDates (start: Date, end: Date) {
     const units: (keyof Duration)[] = ["years", "months", "days"];
@@ -496,16 +497,42 @@ export async function getSummaryForUser (username: string, source: "modmail" | "
     return summary;
 }
 
-export async function createUserSummary (username: string, postId: string, context: TriggerContext) {
-    const summary = await getSummaryForUser(username, "submission", context);
+interface CreateUserSummaryOptions {
+    idempotencyKey?: string;
+}
 
-    const newComment = await context.reddit.submitComment({
-        id: postId,
-        text: json2md(summary),
-    });
-    await newComment.remove();
+export async function createUserSummary (username: string, postId: string, context: TriggerContext, options?: CreateUserSummaryOptions): Promise<boolean> {
+    let lockKey: string | undefined;
+    if (options?.idempotencyKey) {
+        lockKey = await acquireIdempotencyLock(context.redis, options.idempotencyKey, {
+            expiration: addDays(new Date(), 7),
+            verboseLogs: true,
+        });
+        if (!lockKey) {
+            console.log(`User Summary: Summary already created for post ${postId}; skipping duplicate for ${username}`);
+            return false;
+        }
+    }
 
-    console.log(`User Summary: Summary created for ${username}`);
+    let commentCreated = false;
+    try {
+        const summary = await getSummaryForUser(username, "submission", context);
+
+        const newComment = await context.reddit.submitComment({
+            id: postId,
+            text: json2md(summary),
+        });
+        commentCreated = true;
+        await newComment.remove();
+
+        console.log(`User Summary: Summary created for ${username}`);
+        return true;
+    } catch (error) {
+        if (lockKey && !commentCreated) {
+            await releaseIdempotencyLock(context.redis, lockKey);
+        }
+        throw error;
+    }
 }
 
 async function evaluatorsMatched (user: UserExtended, userHistory: (Post | Comment)[], evaluatorVariables: Record<string, JSONValue>, context: TriggerContext): Promise<InstanceType<typeof ALL_RELEVANT_EVALUTORS[number]>[]> {

--- a/src/aiAnalysis/createAISummary.test.ts
+++ b/src/aiAnalysis/createAISummary.test.ts
@@ -1,0 +1,183 @@
+import { JobContext, RedisClient } from "@devvit/public-api";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { CONTROL_SUBREDDIT } from "../constants.js";
+import { createResponse, openAISummaryLookupAndRespond } from "./createAISummary.js";
+import { callOpenAI } from "./openAI.js";
+
+vi.mock("../constants.js", () => ({
+    ALL_RELEVANT_EVALUATORS: [],
+    CONTROL_SUBREDDIT: "BotBouncer",
+    ControlSubredditJob: {
+        OpenAISummaryGather: "openAISummary",
+        OpenAIUpdateTokenStatsMessage: "openAIUpdateTokenStatsMessage",
+    },
+    PostFlairTemplate: {
+        Banned: "banned",
+    },
+}));
+vi.mock("./openAI.js", () => ({
+    callOpenAI: vi.fn(),
+}));
+vi.mock("./gatherUserDetailsForOpenAI.js", () => ({
+    getUserInfoForOpenAI: vi.fn(),
+}));
+vi.mock("../handleControlSubAccountEvaluation.js", () => ({
+    getAccountInitialEvaluationResults: vi.fn(),
+}));
+vi.mock("../userEvaluation/evaluatorVariables.js", () => ({
+    getEvaluatorVariables: vi.fn(),
+}));
+vi.mock("./common.js", () => ({
+    getPromptData: vi.fn(),
+}));
+vi.mock("../settings.js", () => ({
+    getControlSubSettings: vi.fn(),
+}));
+
+type InMemoryRedis = RedisClient & {
+    values: Map<string, string>;
+};
+
+function makeRedis (): InMemoryRedis {
+    const values = new Map<string, string>();
+    const redis = {
+        values,
+        exists: vi.fn(async (key: string) => values.has(key)),
+        get: vi.fn(async (key: string) => values.get(key)),
+        set: vi.fn(async (key: string, value: string) => {
+            values.set(key, value);
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            for (const key of keys) {
+                values.delete(key);
+            }
+        }),
+        watch: vi.fn(async (key: string) => {
+            let pendingValue: string | undefined;
+            return {
+                multi: vi.fn(async () => undefined),
+                set: vi.fn(async (_key: string, value: string) => {
+                    pendingValue = value;
+                }),
+                exec: vi.fn(async () => {
+                    if (values.has(key)) {
+                        throw new Error("transaction conflict");
+                    }
+                    values.set(key, pendingValue ?? "locked");
+                }),
+                discard: vi.fn(async () => undefined),
+            };
+        }),
+    } as unknown as InMemoryRedis;
+
+    return redis;
+}
+
+function makeContext () {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const submitComment = vi.fn().mockResolvedValue({ remove });
+    const context = {
+        subredditName: CONTROL_SUBREDDIT,
+        reddit: {
+            submitComment,
+            modMail: {
+                reply: vi.fn().mockResolvedValue(undefined),
+            },
+        },
+        redis: makeRedis(),
+        scheduler: {
+            runJob: vi.fn().mockResolvedValue(undefined),
+        },
+    } as unknown as JobContext;
+
+    return { context, submitComment, remove };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("createResponse", () => {
+    test("creates only one removed post comment for the same idempotency key", async () => {
+        const { context, submitComment, remove } = makeContext();
+        const options = {
+            postId: "t3_test",
+            output: "summary",
+            idempotencyKey: "openAISummaryResponse:t3_test",
+        };
+
+        expect(await createResponse(options, context)).toBe(true);
+        expect(await createResponse(options, context)).toBe(false);
+
+        expect(submitComment).toHaveBeenCalledOnce();
+        expect(remove).toHaveBeenCalledOnce();
+    });
+
+    test("releases the lock when comment creation fails before a response exists", async () => {
+        const { context, submitComment } = makeContext();
+        submitComment
+            .mockRejectedValueOnce(new Error("Reddit unavailable"))
+            .mockResolvedValueOnce({ remove: vi.fn().mockResolvedValue(undefined) });
+        const options = {
+            postId: "t3_test",
+            output: "summary",
+            idempotencyKey: "openAISummaryResponse:t3_test",
+        };
+
+        await expect(createResponse(options, context)).rejects.toThrow("Reddit unavailable");
+        await expect(createResponse(options, context)).resolves.toBe(true);
+
+        expect(submitComment).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("openAISummaryLookupAndRespond", () => {
+    const event = {
+        name: "openAISummaryLookup",
+        data: {
+            username: "example_user",
+            postId: "t3_test",
+            prompt: "prompt",
+            model: "model",
+        },
+    };
+
+    test("suppresses duplicate model calls and duplicate responses for a post", async () => {
+        const { context, submitComment } = makeContext();
+        vi.mocked(callOpenAI).mockResolvedValue("result");
+
+        await openAISummaryLookupAndRespond(event, context);
+        await openAISummaryLookupAndRespond(event, context);
+
+        expect(callOpenAI).toHaveBeenCalledOnce();
+        expect(submitComment).toHaveBeenCalledOnce();
+        expect(context.scheduler.runJob).toHaveBeenCalledOnce();
+    });
+
+    test("retries response delivery from cache without repeating a completed model call", async () => {
+        const { context, submitComment } = makeContext();
+        submitComment
+            .mockRejectedValueOnce(new Error("Reddit unavailable"))
+            .mockResolvedValueOnce({ remove: vi.fn().mockResolvedValue(undefined) });
+        vi.mocked(callOpenAI).mockResolvedValue("result");
+
+        await expect(openAISummaryLookupAndRespond(event, context)).rejects.toThrow("Reddit unavailable");
+        await expect(openAISummaryLookupAndRespond(event, context)).resolves.toBeUndefined();
+
+        expect(callOpenAI).toHaveBeenCalledOnce();
+        expect(submitComment).toHaveBeenCalledTimes(2);
+    });
+
+    test("releases the lookup lock when the model call fails so the job can retry", async () => {
+        const { context, submitComment } = makeContext();
+        vi.mocked(callOpenAI)
+            .mockRejectedValueOnce(new Error("OpenAI unavailable"))
+            .mockResolvedValueOnce("result");
+
+        await expect(openAISummaryLookupAndRespond(event, context)).rejects.toThrow("OpenAI unavailable");
+        await expect(openAISummaryLookupAndRespond(event, context)).resolves.toBeUndefined();
+
+        expect(callOpenAI).toHaveBeenCalledTimes(2);
+        expect(submitComment).toHaveBeenCalledOnce();
+    });
+});

--- a/src/aiAnalysis/createAISummary.ts
+++ b/src/aiAnalysis/createAISummary.ts
@@ -8,6 +8,7 @@ import { getEvaluatorVariables } from "../userEvaluation/evaluatorVariables.js";
 import { addDays, differenceInDays } from "date-fns";
 import { getPromptData, PromptData } from "./common.js";
 import { getControlSubSettings } from "../settings.js";
+import { acquireIdempotencyLock, releaseIdempotencyLock } from "../idempotency.js";
 import pluralize from "pluralize";
 
 function evaluationResultsToBulletPoints (input: EvaluationResult[], evaluatorVariables: Record<string, unknown>): string[] {
@@ -40,22 +41,56 @@ function evaluationResultsToBulletPoints (input: EvaluationResult[], evaluatorVa
     return bullets;
 }
 
-export async function createResponse (opts: { conversationId?: string; postId?: string; output: string }, context: JobContext) {
+interface CreateResponseOptions {
+    conversationId?: string;
+    postId?: string;
+    output: string;
+    idempotencyKey?: string;
+}
+
+export async function createResponse (opts: CreateResponseOptions, context: JobContext): Promise<boolean> {
     const { conversationId, postId, output } = opts;
-    if (conversationId) {
-        await context.reddit.modMail.reply({
-            conversationId,
-            body: output,
-            isInternal: true,
+    let lockKey: string | undefined;
+    if (opts.idempotencyKey) {
+        lockKey = await acquireIdempotencyLock(context.redis, opts.idempotencyKey, {
+            expiration: addDays(new Date(), 7),
+            verboseLogs: true,
         });
+        if (!lockKey) {
+            console.log(`AI Summary: Response already created for post ${postId}; skipping duplicate`);
+            return false;
+        }
     }
-    if (postId) {
-        const newComment = await context.reddit.submitComment({
-            id: postId,
-            text: output,
-        });
-        await newComment.remove();
+
+    let responseCreated = false;
+    try {
+        if (conversationId) {
+            await context.reddit.modMail.reply({
+                conversationId,
+                body: output,
+                isInternal: true,
+            });
+            responseCreated = true;
+        }
+        if (postId) {
+            const newComment = await context.reddit.submitComment({
+                id: postId,
+                text: output,
+            });
+            responseCreated = true;
+            await newComment.remove();
+        }
+        return true;
+    } catch (error) {
+        if (lockKey && !responseCreated) {
+            await releaseIdempotencyLock(context.redis, lockKey);
+        }
+        throw error;
     }
+}
+
+function getPostResponseIdempotencyKey (postId?: string): string | undefined {
+    return postId ? `openAISummaryResponse:${postId}` : undefined;
 }
 
 function getCacheKeyForUserSummary (username: string) {
@@ -85,6 +120,7 @@ export async function generateOpenAISummary (event: ScheduledJobEvent<JSONObject
             conversationId,
             postId,
             output: `**OpenAI Summary**. Use these results as a guide as they may be inaccurate. **Note**: This is a cached summary, not live.\n\n${cachedSummary}`,
+            idempotencyKey: getPostResponseIdempotencyKey(postId),
         }, context);
         return;
     }
@@ -105,6 +141,7 @@ export async function generateOpenAISummary (event: ScheduledJobEvent<JSONObject
                 { p: "Error generating OpenAI summary: unable to load prompt data. Please contact the developers to resolve this issue." },
                 { blockquote: errorMessage },
             ]),
+            idempotencyKey: getPostResponseIdempotencyKey(postId),
         }, context);
         return;
     }
@@ -128,6 +165,7 @@ export async function generateOpenAISummary (event: ScheduledJobEvent<JSONObject
                 { p: "**OpenAI Summary**. Use these results as a guide as they may be inaccurate." },
                 { p: `Error generating OpenAI summary: could not retrieve user information for ${username}. This may be because the user does not exist or is suspended.` },
             ]),
+            idempotencyKey: getPostResponseIdempotencyKey(postId),
         }, context);
         return;
     }
@@ -154,6 +192,7 @@ export async function generateOpenAISummary (event: ScheduledJobEvent<JSONObject
                 { p: "This user does not meet the requirements for generating an OpenAI summary because of the following reasons:" },
                 { ul: reasonsToSkipCreation },
             ]),
+            idempotencyKey: getPostResponseIdempotencyKey(postId),
         }, context);
         return;
     }
@@ -254,25 +293,63 @@ export async function openAISummaryLookupAndRespond (event: ScheduledJobEvent<JS
         return;
     }
 
-    const result = await callOpenAI({
-        model,
-        temperature,
-        prompt,
-    }, context);
+    const lookupIdentifier = postId ? `openAISummaryLookup:${postId}` : undefined;
+    let lookupLockKey: string | undefined;
+    if (lookupIdentifier) {
+        lookupLockKey = await acquireIdempotencyLock(context.redis, lookupIdentifier, {
+            expiration: addDays(new Date(), 7),
+            verboseLogs: true,
+        });
+        if (!lookupLockKey) {
+            console.log(`AI Summary: Lookup already completed or in progress for post ${postId}; skipping duplicate`);
+            return;
+        }
+    }
 
-    const cacheKey = getCacheKeyForUserSummary(username);
-    await context.redis.set(cacheKey, result, { expiration: addDays(new Date(), 1) });
+    let openAICallCompleted = false;
+    let resultAvailableInCache = false;
+    try {
+        const cacheKey = getCacheKeyForUserSummary(username);
+        const cachedSummary = await context.redis.get(cacheKey);
+        if (cachedSummary) {
+            resultAvailableInCache = true;
+            console.log(`AI Summary: Using cached summary for user ${username} during lookup`);
+            await createResponse({
+                conversationId,
+                postId,
+                output: `**OpenAI Summary**. Use these results as a guide as they may be inaccurate. **Note**: This is a cached summary, not live.\n\n${cachedSummary}`,
+                idempotencyKey: getPostResponseIdempotencyKey(postId),
+            }, context);
+            return;
+        }
 
-    await createResponse({
-        conversationId,
-        postId,
-        output: `**OpenAI Summary**. Use these results as a guide as they may be inaccurate.\n\n${result}`,
-    }, context);
+        const result = await callOpenAI({
+            model,
+            temperature,
+            prompt,
+        }, context);
+        openAICallCompleted = true;
 
-    console.log(`AI Summary: Finished generating OpenAI summary about user ${username}`);
+        await context.redis.set(cacheKey, result, { expiration: addDays(new Date(), 1) });
+        resultAvailableInCache = true;
 
-    await context.scheduler.runJob({
-        name: ControlSubredditJob.OpenAIUpdateTokenStatsMessage,
-        runAt: new Date(),
-    });
+        await createResponse({
+            conversationId,
+            postId,
+            output: `**OpenAI Summary**. Use these results as a guide as they may be inaccurate.\n\n${result}`,
+            idempotencyKey: getPostResponseIdempotencyKey(postId),
+        }, context);
+
+        console.log(`AI Summary: Finished generating OpenAI summary about user ${username}`);
+
+        await context.scheduler.runJob({
+            name: ControlSubredditJob.OpenAIUpdateTokenStatsMessage,
+            runAt: new Date(),
+        });
+    } catch (error) {
+        if (lookupLockKey && (!openAICallCompleted || resultAvailableInCache)) {
+            await releaseIdempotencyLock(context.redis, lookupLockKey);
+        }
+        throw error;
+    }
 }

--- a/src/handleControlSubAccountEvaluation.test.ts
+++ b/src/handleControlSubAccountEvaluation.test.ts
@@ -1,0 +1,124 @@
+import { JobContext, RedisClient } from "@devvit/public-api";
+import { beforeEach, expect, test, vi } from "vitest";
+import { createSubmissionSummaries } from "./handleControlSubAccountEvaluation.js";
+import { createUserSummary } from "./UserSummary/userSummary.js";
+import { getControlSubSettings } from "./settings.js";
+
+vi.mock("@fsvreddit/bot-bouncer-evaluation", () => ({
+    getSocialLinksWithCache: vi.fn(),
+    UserEvaluatorBase: class {},
+}));
+vi.mock("./constants.js", () => ({
+    ALL_RELEVANT_EVALUATORS: [],
+    CONTROL_SUBREDDIT: "BotBouncer",
+    ControlSubredditJob: {
+        OpenAISummaryGather: "openAISummary",
+    },
+    PostFlairTemplate: {
+        Banned: "banned",
+    },
+}));
+vi.mock("./dataStore.js", () => ({
+    getUserStatus: vi.fn().mockResolvedValue({ userStatus: "pending" }),
+    UserStatus: {
+        Pending: "pending",
+        Banned: "banned",
+    },
+}));
+vi.mock("./userEvaluation/evaluatorVariables.js", () => ({
+    getEvaluatorVariables: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("./UserSummary/userSummary.js", () => ({
+    createUserSummary: vi.fn(),
+}));
+vi.mock("./statistics/submitterStatistics.js", () => ({
+    getSubmitterSuccessRate: vi.fn(),
+}));
+vi.mock("./utility.js", () => ({
+    conditionallyCompressString: vi.fn((value: string) => value),
+    conditionallyDecompressString: vi.fn((value: string) => value),
+}));
+vi.mock("./settings.js", () => ({
+    getControlSubSettings: vi.fn(),
+}));
+vi.mock("@fsvreddit/fsv-devvit-helpers", () => ({
+    getPostOrCommentById: vi.fn(),
+    getUserExtended: vi.fn().mockResolvedValue({ username: "example_user" }),
+}));
+
+type InMemoryRedis = RedisClient & {
+    values: Map<string, string>;
+};
+
+function makeRedis (): InMemoryRedis {
+    const values = new Map<string, string>();
+    return {
+        values,
+        exists: vi.fn(async (key: string) => values.has(key)),
+        del: vi.fn(async (...keys: string[]) => {
+            for (const key of keys) {
+                values.delete(key);
+            }
+        }),
+        watch: vi.fn(async (key: string) => {
+            let pendingValue: string | undefined;
+            return {
+                multi: vi.fn(async () => undefined),
+                set: vi.fn(async (_key: string, value: string) => {
+                    pendingValue = value;
+                }),
+                exec: vi.fn(async () => {
+                    if (values.has(key)) {
+                        throw new Error("transaction conflict");
+                    }
+                    values.set(key, pendingValue ?? "locked");
+                }),
+                discard: vi.fn(async () => undefined),
+            };
+        }),
+    } as unknown as InMemoryRedis;
+}
+
+function makeContext () {
+    return {
+        subredditName: "BotBouncer",
+        appSlug: "bot-bouncer",
+        redis: makeRedis(),
+        reddit: {
+            getPostById: vi.fn().mockResolvedValue({ id: "t3_test" }),
+            report: vi.fn().mockResolvedValue(undefined),
+            setPostFlair: vi.fn().mockResolvedValue(undefined),
+        },
+        scheduler: {
+            runJob: vi.fn().mockResolvedValue(undefined),
+        },
+    } as unknown as JobContext;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getControlSubSettings).mockResolvedValue({
+        evaluationDisabled: false,
+        trustedSubmitters: [],
+        reporterBlacklist: [],
+        createAISummaryOnNewPosts: true,
+    });
+});
+
+test("overlapping summary workflows create and schedule summaries only once", async () => {
+    const context = makeContext();
+    let finishSummary: (() => void) | undefined;
+    vi.mocked(createUserSummary).mockImplementation(() => new Promise<boolean>((resolve) => {
+        finishSummary = () => resolve(true);
+    }));
+
+    const firstRun = createSubmissionSummaries("example_user", "t3_test", context);
+    await vi.waitFor(() => expect(createUserSummary).toHaveBeenCalledOnce());
+
+    await createSubmissionSummaries("example_user", "t3_test", context);
+    finishSummary?.();
+    await firstRun;
+
+    expect(createUserSummary).toHaveBeenCalledOnce();
+    expect(context.scheduler.runJob).toHaveBeenCalledOnce();
+});

--- a/src/handleControlSubAccountEvaluation.ts
+++ b/src/handleControlSubAccountEvaluation.ts
@@ -4,12 +4,13 @@ import { getUserStatus, UserStatus } from "./dataStore.js";
 import { ALL_RELEVANT_EVALUTORS, CONTROL_SUBREDDIT, ControlSubredditJob, PostFlairTemplate } from "./constants.js";
 import { getEvaluatorVariables } from "./userEvaluation/evaluatorVariables.js";
 import { createUserSummary } from "./UserSummary/userSummary.js";
-import { addSeconds, addWeeks, subMonths } from "date-fns";
+import { addMinutes, addSeconds, addWeeks, subMonths } from "date-fns";
 import _ from "lodash";
 import { getSubmitterSuccessRate } from "./statistics/submitterStatistics.js";
 import { conditionallyCompressString, conditionallyDecompressString } from "./utility.js";
 import { getControlSubSettings } from "./settings.js";
 import { getPostOrCommentById, getUserExtended } from "@fsvreddit/fsv-devvit-helpers";
+import { acquireIdempotencyLock, releaseIdempotencyLock } from "./idempotency.js";
 
 export interface EvaluatorStats {
     hitCount: number;
@@ -132,6 +133,50 @@ function getEvaluationResultText (result: EvaluationResult): string {
     return text;
 }
 
+export async function createSubmissionSummaries (username: string, postId: string, context: JobContext): Promise<void> {
+    const workflowLockKey = await acquireIdempotencyLock(context.redis, `accountSummaryWorkflow:${postId}`, {
+        expiration: addMinutes(new Date(), 10),
+        verboseLogs: true,
+    });
+    if (!workflowLockKey) {
+        console.log(`User Summary: Summary workflow already completed or in progress for post ${postId}; skipping duplicate`);
+        return;
+    }
+
+    try {
+        await createUserSummary(username, postId, context, {
+            idempotencyKey: `accountSummary:${postId}`,
+        });
+        const controlSubSettings = await getControlSubSettings(context);
+        if (controlSubSettings.createAISummaryOnNewPosts) {
+            const scheduleLockKey = await acquireIdempotencyLock(context.redis, `openAISummarySchedule:${postId}`, {
+                expiration: addMinutes(new Date(), 10),
+                verboseLogs: true,
+            });
+            if (scheduleLockKey) {
+                try {
+                    await context.scheduler.runJob({
+                        name: ControlSubredditJob.OpenAISummaryGather,
+                        data: {
+                            username,
+                            postId,
+                        },
+                        runAt: addSeconds(new Date(), 50),
+                    });
+                } catch (error) {
+                    await releaseIdempotencyLock(context.redis, scheduleLockKey);
+                    throw error;
+                }
+            } else {
+                console.log(`AI Summary: Summary job already scheduled for post ${postId}; skipping duplicate`);
+            }
+        }
+    } catch (error) {
+        await releaseIdempotencyLock(context.redis, workflowLockKey);
+        throw error;
+    }
+}
+
 export async function handleControlSubAccountEvaluation (event: ScheduledJobEvent<JSONObject | undefined>, context: JobContext) {
     if (context.subredditName !== CONTROL_SUBREDDIT) {
         return;
@@ -189,18 +234,7 @@ export async function handleControlSubAccountEvaluation (event: ScheduledJobEven
         const post = await context.reddit.getPostById(postId);
         await context.reddit.report(post, { reason: reportReason.trim().substring(0, 99) }); // Reddit's API limits report reasons to 100 characters.
         if (!event.data?.skipSummary) {
-            await createUserSummary(username, postId, context);
-            const controlSubSettings = await getControlSubSettings(context);
-            if (controlSubSettings.createAISummaryOnNewPosts) {
-                await context.scheduler.runJob({
-                    name: ControlSubredditJob.OpenAISummaryGather,
-                    data: {
-                        username,
-                        postId,
-                    },
-                    runAt: addSeconds(new Date(), 50),
-                });
-            }
+            await createSubmissionSummaries(username, postId, context);
         }
         return;
     }

--- a/src/idempotency.test.ts
+++ b/src/idempotency.test.ts
@@ -1,0 +1,68 @@
+import { RedisClient } from "@devvit/public-api";
+import { acquireIdempotencyLock, getIdempotencyLockKey, releaseIdempotencyLock } from "./idempotency.js";
+
+interface FakeTransaction {
+    multi: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    exec: ReturnType<typeof vi.fn>;
+    discard: ReturnType<typeof vi.fn>;
+}
+
+function makeRedis (existing = false, failExec = false) {
+    const transaction: FakeTransaction = {
+        multi: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+        exec: failExec ? vi.fn().mockRejectedValue(new Error("conflict")) : vi.fn().mockResolvedValue(undefined),
+        discard: vi.fn().mockResolvedValue(undefined),
+    };
+    const redis = {
+        watch: vi.fn().mockResolvedValue(transaction),
+        exists: vi.fn().mockResolvedValue(existing),
+        del: vi.fn().mockResolvedValue(undefined),
+    } as unknown as RedisClient;
+
+    return { redis, transaction };
+}
+
+test("acquires an idempotency lock atomically", async () => {
+    const { redis, transaction } = makeRedis();
+    const expiration = new Date(Date.now() + 60_000);
+
+    const lockKey = await acquireIdempotencyLock(redis, "summary:t3_test", { expiration });
+
+    expect(lockKey).toBe(getIdempotencyLockKey("summary:t3_test"));
+    expect(redis.watch).toHaveBeenCalledWith(lockKey);
+    expect(transaction.set).toHaveBeenCalledWith(lockKey, expect.any(String), { expiration });
+    expect(transaction.exec).toHaveBeenCalledOnce();
+});
+
+test("does not acquire an existing idempotency lock", async () => {
+    const { redis, transaction } = makeRedis(true);
+
+    const lockKey = await acquireIdempotencyLock(redis, "summary:t3_test", {
+        expiration: new Date(Date.now() + 60_000),
+    });
+
+    expect(lockKey).toBeUndefined();
+    expect(transaction.discard).toHaveBeenCalledOnce();
+    expect(transaction.set).not.toHaveBeenCalled();
+});
+
+test("treats a transaction conflict as a duplicate operation", async () => {
+    const { redis } = makeRedis(false, true);
+
+    const lockKey = await acquireIdempotencyLock(redis, "summary:t3_test", {
+        expiration: new Date(Date.now() + 60_000),
+    });
+
+    expect(lockKey).toBeUndefined();
+});
+
+test("releases an idempotency lock for retry", async () => {
+    const { redis } = makeRedis();
+    const lockKey = getIdempotencyLockKey("summary:t3_test");
+
+    await releaseIdempotencyLock(redis, lockKey);
+
+    expect(redis.del).toHaveBeenCalledWith(lockKey);
+});

--- a/src/idempotency.ts
+++ b/src/idempotency.ts
@@ -1,0 +1,43 @@
+import { RedisClient } from "@devvit/public-api";
+
+const IDEMPOTENCY_LOCK_PREFIX = "idempotencyLock:";
+
+export interface IdempotencyLockOptions {
+    expiration: Date;
+    verboseLogs?: boolean;
+}
+
+export function getIdempotencyLockKey (identifier: string): string {
+    return `${IDEMPOTENCY_LOCK_PREFIX}${identifier}`;
+}
+
+export async function acquireIdempotencyLock (redis: RedisClient, identifier: string, options: IdempotencyLockOptions): Promise<string | undefined> {
+    const redisKey = getIdempotencyLockKey(identifier);
+    const txn = await redis.watch(redisKey);
+    await txn.multi();
+
+    if (await redis.exists(redisKey)) {
+        if (options.verboseLogs) {
+            console.log(`Idempotency: Duplicate operation for ${identifier} ignored.`);
+        }
+        await txn.discard();
+        return;
+    }
+
+    await txn.set(redisKey, Date.now().toString(), { expiration: options.expiration });
+
+    try {
+        await txn.exec();
+        return redisKey;
+    } catch (error) {
+        if (options.verboseLogs) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.log(`Idempotency: Duplicate operation for ${identifier} ignored: ${errorMessage}`);
+        }
+        return;
+    }
+}
+
+export async function releaseIdempotencyLock (redis: RedisClient, redisKey: string): Promise<void> {
+    await redis.del(redisKey);
+}


### PR DESCRIPTION
Closes #506

## Summary

Prevents duplicate deterministic account summaries, duplicate OpenAI-summary comments, and repeated OpenAI requests when submission-summary jobs overlap, retry, or are delivered more than once.

## Changes

- Adds a reusable atomic Redis idempotency-lock helper.
- Prevents overlapping account-summary workflows for the same submission post.
- Prevents duplicate deterministic account-summary comments.
- Prevents duplicate OpenAI-summary job scheduling.
- Prevents duplicate OpenAI lookup jobs from making repeated model requests.
- Rechecks the completed-summary cache before calling OpenAI.
- Prevents cached or newly generated OpenAI summaries from being posted more than once to the same submission.
- Releases locks after failures that remain safe to retry.
- Allows failed Reddit comment delivery to retry from cache without another OpenAI request.
- Adds diagnostic logging when duplicate operations are skipped.

## Retry behavior

Separate locks cover:

- the account-summary workflow;
- deterministic account-summary comment creation;
- OpenAI job scheduling;
- OpenAI model lookup; and
- OpenAI-summary response delivery.

This prevents duplicate irreversible work without using one broad marker that could suppress legitimate retries after a temporary failure.

## Tests

Regression tests confirm that:

- locks are acquired atomically;
- existing locks and transaction conflicts suppress duplicate work;
- failed operations can release their locks;
- overlapping workflows create one deterministic summary;
- overlapping workflows schedule one OpenAI-summary job;
- duplicate lookup jobs cause one OpenAI request;
- duplicate response attempts create one removed comment;
- failed Reddit delivery retries from cache without another model call; and
- failed OpenAI requests remain retryable.

## Validation

- `npm.cmd exec -- vitest run src/idempotency.test.ts src/handleControlSubAccountEvaluation.test.ts src/aiAnalysis/createAISummary.test.ts`
- `npm.cmd run lint`
- `npm.cmd exec -- tsc --noEmit`
- `npm.cmd test`
- `git diff --check`