### PR TITLE
Log user summary activity retrieval errors

### DIFF
--- a/src/UserSummary/userSummary.ts
+++ b/src/UserSummary/userSummary.ts
@@ -17,6 +17,7 @@ import { getSubmitterSuccessRate } from "../statistics/submitterStatistics.js";
 import { getSummaryExtras } from "./summaryExtras.js";
 import { ALL_RELEVANT_EVALUTORS, CONTROL_SUBREDDIT } from "../constants.js";
 import { getAppealTextForUser } from "../modmail/appealStore.js";
+import { getErrorDiagnostics } from "../errorDiagnostics.js";
 
 function formatDifferenceInDates (start: Date, end: Date) {
     const units: (keyof Duration)[] = ["years", "months", "days"];
@@ -316,7 +317,9 @@ export async function getSummaryForUser (username: string, source: "modmail" | "
                 limit: 100,
             }).all(),
         ]);
-    } catch {
+    } catch (error) {
+        console.error(`User Summary: Error fetching user activity for ${username}.`, { source, ...getErrorDiagnostics(error) });
+
         if (source === "modmail") {
             const initialEvaluatorsMatched = await getAccountInitialEvaluationResults(username, context);
             summary.push({ p: `At the point of initial evaluation, user matched ${initialEvaluatorsMatched.length} ${pluralize("evaluator", initialEvaluatorsMatched.length)}` });

--- a/src/errorDiagnostics.test.ts
+++ b/src/errorDiagnostics.test.ts
@@ -1,0 +1,58 @@
+import { getErrorDiagnostics } from "./errorDiagnostics.js";
+
+test("error diagnostics retain standard and custom error properties", () => {
+    const cause = new Error("Underlying Reddit API failure");
+    const error = new Error("Could not retrieve user activity") as Error & {
+        cause?: unknown;
+        code?: string;
+        status?: number;
+        requestId?: string;
+    };
+    error.cause = cause;
+    error.code = "REDDIT_API_ERROR";
+    error.status = 403;
+    error.requestId = "request-123";
+
+    const diagnostics = getErrorDiagnostics(error);
+
+    expect(diagnostics.name).toBe("Error");
+    expect(diagnostics.message).toBe("Could not retrieve user activity");
+    expect(diagnostics.code).toBe("REDDIT_API_ERROR");
+    expect(diagnostics.status).toBe(403);
+    expect(diagnostics.cause).toMatchObject({
+        name: "Error",
+        message: "Underlying Reddit API failure",
+    });
+    expect(diagnostics.properties.requestId).toBe("request-123");
+    expect(diagnostics.properties.stack).toEqual(expect.any(String));
+});
+
+test("error diagnostics safely record circular properties", () => {
+    const error = new Error("Circular error") as Error & { metadata?: unknown };
+    error.metadata = { error };
+
+    expect(getErrorDiagnostics(error).properties.metadata).toEqual({ error: "[Circular]" });
+});
+
+test("error diagnostics safely record properties with throwing getters", () => {
+    const error = new Error("Getter error");
+    Object.defineProperty(error, "response", {
+        enumerable: true,
+        get: () => {
+            throw new Error("Response unavailable");
+        },
+    });
+
+    expect(getErrorDiagnostics(error).properties.response).toBe("[Unable to read property: Response unavailable]");
+});
+
+test("error diagnostics handle non-Error thrown values", () => {
+    expect(getErrorDiagnostics("Reddit request failed")).toEqual({
+        name: "string",
+        message: "Reddit request failed",
+        code: undefined,
+        status: undefined,
+        cause: undefined,
+        properties: {},
+    });
+});

--- a/src/errorDiagnostics.ts
+++ b/src/errorDiagnostics.ts
@@ -1,0 +1,105 @@
+export interface ErrorDiagnostics {
+    name: unknown;
+    message: unknown;
+    code: unknown;
+    status: unknown;
+    cause: unknown;
+    properties: Record<string, unknown>;
+}
+
+const PRIMARY_ERROR_PROPERTIES = new Set<PropertyKey>(["name", "message", "code", "status", "cause"]);
+
+function propertyReadFailure (error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return `[Unable to read property: ${message}]`;
+}
+
+function readProperty (value: object, property: PropertyKey): unknown {
+    try {
+        return Reflect.get(value, property);
+    } catch (error) {
+        return propertyReadFailure(error);
+    }
+}
+
+function propertyNameForLog (property: PropertyKey): string {
+    return String(property);
+}
+
+function sanitizeForLogging (value: unknown, seen: WeakSet<object>): unknown {
+    if (value === null || value === undefined) {
+        return value;
+    }
+
+    if (typeof value === "bigint") {
+        return value.toString();
+    }
+
+    if (typeof value === "symbol" || typeof value === "function") {
+        return String(value);
+    }
+
+    if (typeof value !== "object") {
+        return value;
+    }
+
+    if (seen.has(value)) {
+        return "[Circular]";
+    }
+    seen.add(value);
+
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? String(value) : value.toISOString();
+    }
+
+    if (value instanceof Error) {
+        return buildErrorDiagnostics(value, seen);
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(item => sanitizeForLogging(item, seen));
+    }
+
+    const sanitized: Record<string, unknown> = {};
+    for (const property of Reflect.ownKeys(value)) {
+        sanitized[propertyNameForLog(property)] = sanitizeForLogging(readProperty(value, property), seen);
+    }
+    return sanitized;
+}
+
+function buildErrorDiagnostics (error: object, seen: WeakSet<object>): ErrorDiagnostics {
+    const properties: Record<string, unknown> = {};
+
+    for (const property of Reflect.ownKeys(error)) {
+        if (PRIMARY_ERROR_PROPERTIES.has(property)) {
+            continue;
+        }
+        properties[propertyNameForLog(property)] = sanitizeForLogging(readProperty(error, property), seen);
+    }
+
+    return {
+        name: sanitizeForLogging(readProperty(error, "name"), seen),
+        message: sanitizeForLogging(readProperty(error, "message"), seen),
+        code: sanitizeForLogging(readProperty(error, "code"), seen),
+        status: sanitizeForLogging(readProperty(error, "status"), seen),
+        cause: sanitizeForLogging(readProperty(error, "cause"), seen),
+        properties,
+    };
+}
+
+export function getErrorDiagnostics (error: unknown): ErrorDiagnostics {
+    if (typeof error === "object" && error !== null) {
+        const seen = new WeakSet();
+        seen.add(error);
+        return buildErrorDiagnostics(error, seen);
+    }
+
+    return {
+        name: typeof error,
+        message: String(error),
+        code: undefined,
+        status: undefined,
+        cause: undefined,
+        properties: {},
+    };
+}


### PR DESCRIPTION
Closes #508. Resolves an issue flagged by moderator on July 15: https://discord.com/channels/1364475628056744036/1511230914443608246/1527025297055027430

## Summary

- Preserves user-activity retrieval errors instead of discarding them
- Logs structured diagnostic information for failed user-summary activity requests
- Safely serializes standard errors, custom properties, nested causes, circular references, and non-Error values
- Leaves the existing moderator-facing summary message unchanged

## Validation

- npm.cmd run lint
- npm.cmd exec -- tsc --noEmit
- npm.cmd test
- git diff --check