### PR TITLE
Fix OpenAI key typing for heterogeneous evaluator unions

### DIFF
--- a/src/UserSummary/userSummary.ts
+++ b/src/UserSummary/userSummary.ts
@@ -519,7 +519,14 @@ async function evaluatorsMatched (user: UserExtended, userHistory: (Post | Comme
             continue;
         }
 
-        if (evaluator.needsOpenAiKey && openAIEvaluationKey) {
+        if (
+            "needsOpenAiKey" in evaluator &&
+            evaluator.needsOpenAiKey &&
+            openAIEvaluationKey &&
+            "setOpenAiKey" in evaluator &&
+            typeof evaluator.setOpenAiKey === "function"
+        ) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- Runtime-checked above.
             evaluator.setOpenAiKey(openAIEvaluationKey);
         }
 

--- a/src/handleClientPostOrComment.ts
+++ b/src/handleClientPostOrComment.ts
@@ -367,7 +367,14 @@ async function checkAndReportPotentialBot (username: string, target: Post | Comm
             continue;
         }
 
-        if (evaluator.needsOpenAiKey && openAIEvaluationKey) {
+        if (
+            "needsOpenAiKey" in evaluator &&
+            evaluator.needsOpenAiKey &&
+            openAIEvaluationKey &&
+            "setOpenAiKey" in evaluator &&
+            typeof evaluator.setOpenAiKey === "function"
+        ) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- Runtime-checked above.
             evaluator.setOpenAiKey(openAIEvaluationKey);
         }
 

--- a/src/handleControlSubAccountEvaluation.ts
+++ b/src/handleControlSubAccountEvaluation.ts
@@ -75,7 +75,14 @@ export async function evaluateUserAccount (options: EvaluateUserAccountOptions, 
     const openAIEvaluationKey = await context.settings.get<string>(AppSetting.OpenAIEvaluationKey);
 
     await Promise.all(_.compact(matchedEvaluators).map(async (evaluator) => {
-        if (evaluator.needsOpenAiKey && openAIEvaluationKey) {
+        if (
+            "needsOpenAiKey" in evaluator &&
+            evaluator.needsOpenAiKey &&
+            openAIEvaluationKey &&
+            "setOpenAiKey" in evaluator &&
+            typeof evaluator.setOpenAiKey === "function"
+        ) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- Runtime-checked above.
             evaluator.setOpenAiKey(openAIEvaluationKey);
         }
 

--- a/src/userEvaluation/flaggedUsersRechecks.ts
+++ b/src/userEvaluation/flaggedUsersRechecks.ts
@@ -132,7 +132,14 @@ export async function recheckFlaggedUser (username: string, context: JobContext)
             continue;
         }
 
-        if (evaluator.needsOpenAiKey && openAIEvaluationKey) {
+        if (
+            "needsOpenAiKey" in evaluator &&
+            evaluator.needsOpenAiKey &&
+            openAIEvaluationKey &&
+            "setOpenAiKey" in evaluator &&
+            typeof evaluator.setOpenAiKey === "function"
+        ) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- Runtime-checked above.
             evaluator.setOpenAiKey(openAIEvaluationKey);
         }
 


### PR DESCRIPTION
﻿## Summary

Fixes OpenAI evaluator key handling for heterogeneous evaluator unions.

Some evaluator implementations support OpenAI configuration through `needsOpenAiKey` and `setOpenAiKey`, while other evaluator types do not expose those members. Direct property access therefore caused TypeScript errors across the evaluator union.

This patch:

- checks for `needsOpenAiKey` and `setOpenAiKey` at runtime before accessing them;
- verifies that `setOpenAiKey` is callable before invoking it;
- applies the same handling in all four evaluator execution paths;
- uses a narrowly scoped ESLint suppression for the call after the runtime checks because ESLint cannot resolve the narrowed heterogeneous union.

## Files changed

- `src/UserSummary/userSummary.ts`
- `src/handleClientPostOrComment.ts`
- `src/handleControlSubAccountEvaluation.ts`
- `src/userEvaluation/flaggedUsersRechecks.ts`

## Validation

- `npm.cmd exec -- tsc --noEmit`
- `npm.cmd exec -- eslint .`
- `git diff --check`
- `npm.cmd test`

Closes #513.
