### PR TITLE
Fix client-subreddit modmail note delivery

### DIFF
--- a/src/modmail/clientSubModmail.test.ts
+++ b/src/modmail/clientSubModmail.test.ts
@@ -1,0 +1,175 @@
+import type { TriggerContext } from "@devvit/public-api";
+import type { ModmailMessage } from "./modmail.js";
+
+const mocks = vi.hoisted(() => ({
+    getUserStatus: vi.fn(),
+    isBanned: vi.fn(),
+    wasUserBannedByApp: vi.fn(),
+}));
+
+vi.mock("../dataStore.js", () => ({
+    getUserStatus: mocks.getUserStatus,
+    UserStatus: { Banned: "banned" },
+}));
+
+vi.mock("../handleClientSubredditClassificationChanges.js", () => ({
+    wasUserBannedByApp: mocks.wasUserBannedByApp,
+}));
+
+vi.mock("../settings.js", () => ({
+    AppSetting: { AddModmailIfNotBannedYet: "addModmailIfNotBannedYet" },
+    CONFIGURATION_DEFAULTS: {
+        noteClient: "/u/{account} is listed at {link} for /r/{subreddit}.",
+    },
+}));
+
+vi.mock("devvit-helpers", () => ({
+    isBanned: mocks.isBanned,
+}));
+
+import { handleClientSubredditModmail } from "./clientSubModmail.js";
+
+interface TestContext {
+    context: TriggerContext;
+    getPostById: ReturnType<typeof vi.fn>;
+    reply: ReturnType<typeof vi.fn>;
+    redisValues: Map<string, string>;
+}
+
+function createContext (): TestContext {
+    const redisValues = new Map<string, string>();
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const getPostById = vi.fn().mockResolvedValue({ permalink: "https://reddit.com/r/BotBouncer/comments/test" });
+
+    const context = {
+        subredditName: "testsub",
+        reddit: {
+            getCurrentSubredditName: vi.fn().mockResolvedValue("testsub"),
+            getPostById,
+            modMail: { reply },
+        },
+        settings: {
+            get: vi.fn().mockResolvedValue(false),
+        },
+        redis: {
+            exists: vi.fn((...keys: string[]) => Promise.resolve(keys.filter(key => redisValues.has(key)).length)),
+            set: vi.fn((key: string, value: string, options?: { nx?: boolean }) => {
+                if (options?.nx && redisValues.has(key)) {
+                    return Promise.resolve("");
+                }
+                redisValues.set(key, value);
+                return Promise.resolve("OK");
+            }),
+            del: vi.fn((...keys: string[]) => {
+                for (const key of keys) {
+                    redisValues.delete(key);
+                }
+                return Promise.resolve();
+            }),
+        },
+    } as unknown as TriggerContext;
+
+    return { context, getPostById, reply, redisValues };
+}
+
+function createModmail (overrides: Partial<ModmailMessage> = {}): ModmailMessage {
+    return {
+        conversationId: "conversation-1",
+        createdAt: new Date(),
+        subject: "Ban dispute",
+        participant: "BannedUser",
+        messageAuthor: "BannedUser",
+        messageAuthorIsMod: false,
+        bodyMarkdown: "Please review my ban.",
+        isFirstMessage: false,
+        isInternal: false,
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUserStatus.mockResolvedValue({
+        trackingPostId: "t3_tracking",
+        userStatus: "banned",
+    });
+    mocks.isBanned.mockResolvedValue(true);
+    mocks.wasUserBannedByApp.mockResolvedValue(true);
+});
+
+test("adds the note when a banned participant replies to a ban-generated conversation", async () => {
+    const { context, reply } = createContext();
+
+    await handleClientSubredditModmail(createModmail({ isFirstMessage: false }), context);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({
+        conversationId: "conversation-1",
+        isInternal: true,
+    }));
+});
+
+test("adds the note when the participant initiates the conversation", async () => {
+    const { context, reply } = createContext();
+
+    await handleClientSubredditModmail(createModmail({ isFirstMessage: true }), context);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+});
+
+test("adds no more than one note for multiple participant messages in the same conversation", async () => {
+    const { context, reply } = createContext();
+    const modmail = createModmail();
+
+    await handleClientSubredditModmail(modmail, context);
+    await handleClientSubredditModmail(modmail, context);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+});
+
+test("uses the conversation lock to prevent concurrent duplicate notes", async () => {
+    const { context, reply } = createContext();
+    const modmail = createModmail();
+
+    await Promise.all([
+        handleClientSubredditModmail(modmail, context),
+        handleClientSubredditModmail(modmail, context),
+    ]);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+});
+
+test("does not add the participant note for moderator messages", async () => {
+    const { context, reply } = createContext();
+
+    await handleClientSubredditModmail(createModmail({
+        messageAuthor: "ReviewingMod",
+        messageAuthorIsMod: true,
+    }), context);
+
+    expect(reply).not.toHaveBeenCalled();
+});
+
+test("releases the conversation lock when note delivery fails so a later message can retry", async () => {
+    const { context, reply, redisValues } = createContext();
+    reply
+        .mockRejectedValueOnce(new Error("Reddit API unavailable"))
+        .mockResolvedValueOnce(undefined);
+
+    await expect(handleClientSubredditModmail(createModmail(), context)).rejects.toThrow("Reddit API unavailable");
+    expect([...redisValues.keys()].some(key => key.startsWith("clientModmailNoteLock:"))).toBe(false);
+
+    await handleClientSubredditModmail(createModmail({ bodyMarkdown: "Following up." }), context);
+
+    expect(reply).toHaveBeenCalledTimes(2);
+    expect([...redisValues.keys()].some(key => key.startsWith("clientModmailNoteSent:"))).toBe(true);
+});
+
+test("allows one note in each separate conversation", async () => {
+    const { context, reply } = createContext();
+
+    await handleClientSubredditModmail(createModmail({ conversationId: "conversation-1" }), context);
+    await handleClientSubredditModmail(createModmail({ conversationId: "conversation-2" }), context);
+
+    expect(reply).toHaveBeenCalledTimes(2);
+});

--- a/src/modmail/clientSubModmail.ts
+++ b/src/modmail/clientSubModmail.ts
@@ -1,16 +1,16 @@
-import { TriggerContext } from "@devvit/public-api";
+import type { TriggerContext } from "@devvit/public-api";
+import { addMinutes, addMonths } from "date-fns";
 import { getUserStatus, UserStatus } from "../dataStore.js";
 import { wasUserBannedByApp } from "../handleClientSubredditClassificationChanges.js";
 import { AppSetting, CONFIGURATION_DEFAULTS } from "../settings.js";
-import { ModmailMessage } from "./modmail.js";
+import type { ModmailMessage } from "./modmail.js";
 import { isBanned } from "devvit-helpers";
 import json2md from "json2md";
 
-export async function handleClientSubredditModmail (modmail: ModmailMessage, context: TriggerContext) {
-    if (!modmail.isFirstMessage) {
-        return;
-    }
+const CLIENT_MODMAIL_NOTE_LOCK_PREFIX = "clientModmailNoteLock";
+const CLIENT_MODMAIL_NOTE_SENT_PREFIX = "clientModmailNoteSent";
 
+export async function handleClientSubredditModmail (modmail: ModmailMessage, context: TriggerContext) {
     const username = modmail.participant;
     if (!username) {
         return;
@@ -36,11 +36,7 @@ export async function handleClientSubredditModmail (modmail: ModmailMessage, con
                 { p: `*I am a bot, and this action was performed automatically. To turn off this notification in the future, please adjust your settings.*` },
             ];
 
-            await context.reddit.modMail.reply({
-                conversationId: modmail.conversationId,
-                body: json2md(message),
-                isInternal: true,
-            });
+            await addInternalNoteOnce(modmail.conversationId, json2md(message), context);
         }
         return;
     }
@@ -57,9 +53,38 @@ export async function handleClientSubredditModmail (modmail: ModmailMessage, con
         .replaceAll("{subreddit}", subredditName)
         .replaceAll("{account}", username);
 
-    await context.reddit.modMail.reply({
-        body: message,
-        conversationId: modmail.conversationId,
-        isInternal: true,
+    await addInternalNoteOnce(modmail.conversationId, message, context);
+}
+
+async function addInternalNoteOnce (conversationId: string, body: string, context: TriggerContext) {
+    const noteSentKey = `${CLIENT_MODMAIL_NOTE_SENT_PREFIX}:${conversationId}`;
+    if (await context.redis.exists(noteSentKey)) {
+        return;
+    }
+
+    const noteLockKey = `${CLIENT_MODMAIL_NOTE_LOCK_PREFIX}:${conversationId}`;
+    const lockAcquired = await context.redis.set(noteLockKey, "true", {
+        nx: true,
+        expiration: addMinutes(new Date(), 5),
     });
+    if (!lockAcquired) {
+        return;
+    }
+
+    try {
+        // Another invocation may have completed between the initial check and this lock being acquired.
+        if (await context.redis.exists(noteSentKey)) {
+            return;
+        }
+
+        await context.reddit.modMail.reply({
+            body,
+            conversationId,
+            isInternal: true,
+        });
+
+        await context.redis.set(noteSentKey, "true", { expiration: addMonths(new Date(), 6) });
+    } finally {
+        await context.redis.del(noteLockKey);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes client-subreddit private modmail-note delivery when a banned user replies to a conversation generated during the ban process.

## Root cause

The client-subreddit handler returned unless the incoming message was the first message in the entire conversation.

A user's reply to a ban-generated conversation is not the first conversation message, so the automated internal moderator note was skipped.

## Changes

- Removes the conversation-level `isFirstMessage` restriction.
- Continues requiring the current message author to be the conversation participant.
- Adds a conversation-scoped Redis completion marker.
- Uses an atomic, short-lived Redis lock to prevent concurrent duplicate notes.
- Writes the completion marker only after the internal note is posted successfully.
- Releases the lock after delivery failures so a later participant message can retry.
- Applies the same once-per-conversation protection to the optional not-banned-yet note.

## Tests

- `npm.cmd exec -- vitest run src/modmail/clientSubModmail.test.ts`
- `npm.cmd test`
- `npm.cmd exec -- tsc --noEmit`
- `npm.cmd run lint`
- `git diff --check`

Regression coverage includes:

- participant replies to ban-generated conversations;
- participant-initiated conversations;
- repeated participant messages;
- concurrent handler invocations;
- moderator-authored messages;
- failed delivery followed by a later retry; and
- separate conversations for the same participant.

Closes #516