### PR TITLE
Prevent recording failed client-subreddit bans

### DIFF
--- a/src/handleClientSubredditClassificationChanges.test.ts
+++ b/src/handleClientSubredditClassificationChanges.test.ts
@@ -1,0 +1,102 @@
+import type { SettingsValues, TriggerContext } from "@devvit/public-api";
+import { AppSetting } from "./settings.js";
+
+interface SortedSetMember {
+    member: string;
+    score: number;
+}
+
+type ZAdd = (key: string, value: SortedSetMember) => Promise<void>;
+
+const mocks = vi.hoisted(() => ({
+    recordBanForSummary: vi.fn(),
+    setCleanupForUser: vi.fn(),
+}));
+
+vi.mock("./cleanup.js", () => ({
+    setCleanupForUser: mocks.setCleanupForUser,
+}));
+
+vi.mock("./modmail/actionSummary.js", () => ({
+    recordBanForSummary: mocks.recordBanForSummary,
+    recordUnbanForSummary: vi.fn(),
+    removeRecordOfBanForSummary: vi.fn(),
+}));
+
+import { completeSuccessfulClientSubredditBan } from "./handleClientSubredditClassificationChanges.js";
+
+function createContext () {
+    const zAdd = vi.fn<ZAdd>().mockResolvedValue(undefined);
+    const addModNote = vi.fn().mockResolvedValue(undefined);
+    const context = {
+        appSlug: "bot-bouncer",
+        redis: { zAdd },
+        reddit: { addModNote },
+    } as unknown as TriggerContext;
+
+    return { context, zAdd, addModNote };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.recordBanForSummary.mockResolvedValue(undefined);
+    mocks.setCleanupForUser.mockResolvedValue(undefined);
+});
+
+test("does not record successful-ban side effects when the Reddit ban fails", async () => {
+    const { context, zAdd, addModNote } = createContext();
+    const settings = {
+        [AppSetting.AddModNoteOnClassificationChange]: true,
+        [AppSetting.RemoveFromModqueueWhenBanning]: true,
+    } as SettingsValues;
+
+    const result = await completeSuccessfulClientSubredditBan(
+        { status: "rejected", reason: new Error("Reddit rejected the ban") },
+        "TestUser",
+        "testsub",
+        settings,
+        context,
+    );
+
+    expect(result).toBe(false);
+    expect(zAdd).not.toHaveBeenCalled();
+    expect(mocks.setCleanupForUser).not.toHaveBeenCalled();
+    expect(mocks.recordBanForSummary).not.toHaveBeenCalled();
+    expect(addModNote).not.toHaveBeenCalled();
+});
+
+test("records the ban and queues modqueue cleanup after a successful Reddit ban", async () => {
+    const { context, zAdd } = createContext();
+    const settings = {
+        [AppSetting.AddModNoteOnClassificationChange]: false,
+        [AppSetting.RemoveFromModqueueWhenBanning]: true,
+    } as SettingsValues;
+
+    const result = await completeSuccessfulClientSubredditBan(
+        { status: "fulfilled", value: undefined },
+        "TestUser",
+        "testsub",
+        settings,
+        context,
+    );
+
+    expect(result).toBe(true);
+    expect(zAdd.mock.calls.map(([key, value]) => ({
+        key,
+        member: value.member,
+        scoreType: typeof value.score,
+    }))).toEqual([
+        {
+            key: "BanStore",
+            member: "TestUser",
+            scoreType: "number",
+        },
+        {
+            key: "ModqueueRemovalStore",
+            member: "TestUser",
+            scoreType: "number",
+        },
+    ]);
+    expect(mocks.setCleanupForUser).toHaveBeenCalledWith("TestUser", context.redis);
+    expect(mocks.recordBanForSummary).toHaveBeenCalledWith("TestUser", context.redis);
+});

--- a/src/handleClientSubredditClassificationChanges.ts
+++ b/src/handleClientSubredditClassificationChanges.ts
@@ -21,6 +21,42 @@ export async function recordBan (username: string, redis: RedisClient) {
     console.log(`Ban recorded for ${username}`);
 }
 
+export async function completeSuccessfulClientSubredditBan (
+    banResult: PromiseSettledResult<unknown>,
+    username: string,
+    subredditName: string,
+    settings: SettingsValues,
+    context: TriggerContext,
+): Promise<boolean> {
+    if (banResult.status === "rejected") {
+        return false;
+    }
+
+    await recordBan(username, context.redis);
+    await recordBanForSummary(username, context.redis);
+
+    if (settings[AppSetting.AddModNoteOnClassificationChange]) {
+        let modNoteText = "User banned by Bot Bouncer";
+        const currentStatus = await getUserStatus(username, context);
+        if (currentStatus?.trackingPostId) {
+            modNoteText += `. Tracking post: ${postIdToShortLink(currentStatus.trackingPostId)}`;
+        }
+
+        await context.reddit.addModNote({
+            note: modNoteText,
+            subreddit: subredditName,
+            user: username,
+            label: "BOT_BAN",
+        });
+    }
+
+    if (settings[AppSetting.RemoveFromModqueueWhenBanning]) {
+        await addUserToModqueueRemovalStore(username, context);
+    }
+
+    return true;
+}
+
 export async function removeRecordOfBan (username: string, redis: RedisClient) {
     await redis.zRem(BAN_STORE, [username]);
     await removeRecordOfBanForSummary(username, redis);
@@ -223,9 +259,15 @@ async function handleSetBanned (username: string, subredditName: string, setting
         }
 
         const results = await Promise.allSettled(promises);
+        const banResult = results[0];
 
-        await recordBan(username, context.redis);
-        await recordBanForSummary(username, context.redis);
+        const banSucceeded = await completeSuccessfulClientSubredditBan(
+            banResult,
+            username,
+            subredditName,
+            settings,
+            context,
+        );
 
         const reinstatableContent = removableContent.filter(item => item.userReportReasons.length === 0);
         if (reinstatableContent.length > 0) {
@@ -239,31 +281,17 @@ async function handleSetBanned (username: string, subredditName: string, setting
             }
         }
 
-        const failedPromises = results.filter(result => result.status === "rejected");
-        if (failedPromises.length > 0) {
-            console.error(`Classification Update: Some errors occurred banning ${username} on ${subredditName}.`);
-            console.log(failedPromises);
-        } else {
+        if (banResult.status === "rejected") {
+            console.error(`Classification Update: Failed to ban ${username} on ${subredditName}.`);
+            console.log(banResult.reason);
+        }
+
+        const failedContentActions = results.slice(1).filter(result => result.status === "rejected");
+        if (failedContentActions.length > 0) {
+            console.error(`Classification Update: Some content removal or locking actions failed for ${username} on ${subredditName}.`);
+            console.log(failedContentActions);
+        } else if (banSucceeded) {
             console.log(`Classification Update: 💥 ${username} has been banned following classification update. ${removableContent.length} ${pluralize("item", removableContent.length)} removed.`);
-        }
-
-        if (settings[AppSetting.AddModNoteOnClassificationChange]) {
-            let modNoteText = "User banned by Bot Bouncer";
-            const currentStatus = await getUserStatus(username, context);
-            if (currentStatus?.trackingPostId) {
-                modNoteText += `. Tracking post: ${postIdToShortLink(currentStatus.trackingPostId)}`;
-            }
-
-            await context.reddit.addModNote({
-                note: modNoteText,
-                subreddit: subredditName,
-                user: username,
-                label: "BOT_BAN",
-            });
-        }
-
-        if (settings[AppSetting.RemoveFromModqueueWhenBanning]) {
-            await addUserToModqueueRemovalStore(username, context);
         }
     } else if (actionToTake === ActionType.Filter) {
         await Promise.all(removableContent.map(async (item) => {


### PR DESCRIPTION
## Summary

Prevents failed client-subreddit ban attempts from being recorded as successful Bot Bouncer bans.

## Root cause

The Reddit ban request, content removals, and optional content locks were executed together through `Promise.allSettled()`.

Bot Bouncer then recorded a successful ban before confirming whether the Reddit ban request itself succeeded.

## Changes

- Treats the Reddit ban result separately from content-action results.
- Records the account in `BAN_STORE` only after a successful ban.
- Records the ban in the action summary only after a successful ban.
- Adds the “User banned by Bot Bouncer” mod note only after a successful ban.
- Adds the account to the modqueue-removal store only after a successful ban.
- Logs failed ban requests separately from content-removal and locking failures.

## Tests

Regression coverage verifies that:

- failed Reddit bans do not create successful-ban records, summaries, notes, or modqueue entries; and
- successful Reddit bans still create the expected records and downstream actions.

Validation performed:

- targeted Vitest regression test
- TypeScript compilation
- ESLint
- whitespace validation

Closes #518